### PR TITLE
Reduce Mpris requests quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note: you can also [install it from extensions.gnome.org](https://extensions.gno
 - Clone this repository `$ git clone https://github.com/Moon-0xff/gnome-mpris-label.git`
 - Switch to the latest version branch: `$ git checkout latest-version`  
   you can skip this step if you want a not-yet-finished version of the upcoming release. Although it could be broken or buggy
-- Run the installation script `sh gnome-mpris-label/install.sh`
+- Run the installation script `$ sh gnome-mpris-label/install.sh`
 
 or if you don't want to use the installation script:
 - Rename the `gnome-mpris-label` folder to `mprisLabel@moon-0xff.github.com`

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Down below there's a list of stuff you can help me with, I'm not actively workin
 Note: you can also [install it from extensions.gnome.org](https://extensions.gnome.org/extension/4928/mpris-label) with just one click. If this is your first time installing an extension perhaps you don't have the necessary software to do it though. Visit the page for further instructions
 
 - Clone this repository `$ git clone https://github.com/Moon-0xff/gnome-mpris-label.git`
-- Switch to the latest version branch: `$ git checkout latest-version`  
-  you can skip this step if you want a not-yet-finished version of the upcoming release. Although it could be broken or buggy
+- [Optional] If you want a not-yet-finished version of the upcoming release, you can try the development version although it could be broken or buggy. To switch to the latest development branch: `$ git checkout latest-version`  
 - Run the installation script `$ sh gnome-mpris-label/install.sh`
 
 or if you don't want to use the installation script:

--- a/README.md
+++ b/README.md
@@ -28,14 +28,12 @@ Down below there's a list of stuff you can help me with, I'm not actively workin
 Note: you can also [install it from extensions.gnome.org](https://extensions.gnome.org/extension/4928/mpris-label) with just one click. If this is your first time installing an extension perhaps you don't have the necessary software to do it though. Visit the page for further instructions
 
 - Clone this repository `$ git clone https://github.com/Moon-0xff/gnome-mpris-label.git`
+- Switch to the latest version branch: `$ git checkout latest-version`  
+  you can skip this step if you want a not-yet-finished version of the upcoming release. Although it could be broken or buggy
+- Run the installation script `sh gnome-mpris-label/install.sh`
 
-To install, either:
-- Run the install script `sh gnome-mpris-label/install.sh`
-
-or
-
+or if you don't want to use the installation script:
 - Rename the `gnome-mpris-label` folder to `mprisLabel@moon-0xff.github.com`
 - Copy or move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
 
-Finally, restart GNOME and it should be enabled by default, check tweaks or extensions if it's not.
-
+Finally, restart GNOME and it should be enabled by default, check extensions if it's not.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ or
 - Rename it to `mprisLabel@moon-0xff.github.com`
 - Move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
 
-Finally, restart GNOME and it should be enabled by default, check tweaks or extensions if it's not
+Finally, restart GNOME and it should be enabled by default, check tweaks or extensions if it's not.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To install, either:
 
 or
 
-- Rename it to `mprisLabel@moon-0xff.github.com`
-- Move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
+- Rename the `gnome-mpris-label` folder to `mprisLabel@moon-0xff.github.com`
+- Copy or move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
 
 Finally, restart GNOME and it should be enabled by default, check tweaks or extensions if it's not.
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ or if you don't want to use the installation script:
 - Rename the `gnome-mpris-label` folder to `mprisLabel@moon-0xff.github.com`
 - Copy or move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
 
-Finally, restart GNOME and it should be enabled by default, check extensions if it's not.
+Finally, restart GNOME and it should be enabled by default, check tweaks or extensions if it's not.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Down below there's a list of stuff you can help me with, I'm not actively workin
 Note: you can also [install it from extensions.gnome.org](https://extensions.gnome.org/extension/4928/mpris-label) with just one click. If this is your first time installing an extension perhaps you don't have the necessary software to do it though. Visit the page for further instructions
 
 - Clone this repository `$ git clone https://github.com/Moon-0xff/gnome-mpris-label.git`
+
+To install:
+- Run the install script `sh install.sh`
+or
 - Rename it to `mprisLabel@moon-0xff.github.com`
 - Move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
 - Restart GNOME and it should be enabled by default, check tweaks or extensions if it's not

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note: you can also [install it from extensions.gnome.org](https://extensions.gno
 - Clone this repository `$ git clone https://github.com/Moon-0xff/gnome-mpris-label.git`
 
 To install, either:
-- Run the install script `sh install.sh`
+- Run the install script `sh gnome-mpris-label/install.sh`
 
 or
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ Note: you can also [install it from extensions.gnome.org](https://extensions.gno
 
 - Clone this repository `$ git clone https://github.com/Moon-0xff/gnome-mpris-label.git`
 
-To install:
+To install, either:
 - Run the install script `sh install.sh`
+
 or
+
 - Rename it to `mprisLabel@moon-0xff.github.com`
 - Move it to your gnome-shell extensions folder. Default path is `~/.local/share/gnome-shell/extensions/`
-- Restart GNOME and it should be enabled by default, check tweaks or extensions if it's not
+
+Finally, restart GNOME and it should be enabled by default, check tweaks or extensions if it's not
 

--- a/dbus.js
+++ b/dbus.js
@@ -50,7 +50,7 @@ var getPlayerStatus = function getPlayerStatus(playerAddress) {
 	return statusProxy.PlaybackStatus;
 }
 
-var getMetadata = function getMetadata(address,field){
+var getMetadata = function getMetadata(address,field){//could we split this function to source metadata array from DBus only once and split the string separately?
 		let metadataWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);
 		let metadataProxy = metadataWrapper(Gio.DBus.session,address, "/org/mpris/MediaPlayer2");
 		let metadataField = "";

--- a/dbus.js
+++ b/dbus.js
@@ -20,7 +20,7 @@ const dBusInterface = `
 </node>`
 
 var getDBusList = function getDBusList(){
-	let dBusProxyWrapper = Gio.DBusProxy.makeProxyWrapper(dBusInterface); let start_time = new Date().getTime();log("mpris-label - -----------------------------------------------");
+	let dBusProxyWrapper = Gio.DBusProxy.makeProxyWrapper(dBusInterface); let start_time = new Date().getTime();
 	let dBusProxy = dBusProxyWrapper(Gio.DBus.session,"org.freedesktop.DBus","/org/freedesktop/DBus");end_time = new Date().getTime(); step = end_time - start_time; log("mpris-label - dBusList: "+step+"ms");
 	let dBusList = dBusProxy.ListNamesSync()[0];end_time = new Date().getTime();
 	return dBusList.filter(element => element.startsWith("org.mpris.MediaPlayer2"));
@@ -28,7 +28,7 @@ var getDBusList = function getDBusList(){
 
 var getPlayerStatus = function getPlayerStatus(playerAddress) {
 	let statusWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);let start_time = new Date().getTime();
-	let statusProxy = statusWrapper(Gio.DBus.session,playerAddress, "/org/mpris/MediaPlayer2");end_time = new Date().getTime(); step = end_time - start_time; log("mpris-label - playbackStatus:("+playerAddress.substring(23)+"): "+step+"ms");
+	let statusProxy = statusWrapper(Gio.DBus.session,playerAddress, "/org/mpris/MediaPlayer2");end_time = new Date().getTime(); step = end_time - start_time; log("mpris-label - playbackStatus:("+playerAddress.substring(23)+"): "+step+"ms ("+statusProxy.PlaybackStatus+")");
 	return statusProxy.PlaybackStatus;
 }
 

--- a/dbus.js
+++ b/dbus.js
@@ -20,24 +20,26 @@ const dBusInterface = `
 </node>`
 
 var getDBusList = function getDBusList(){
-	let dBusProxyWrapper = Gio.DBusProxy.makeProxyWrapper(dBusInterface);
-	let dBusProxy = dBusProxyWrapper(Gio.DBus.session,"org.freedesktop.DBus","/org/freedesktop/DBus");
-	let dBusList = dBusProxy.ListNamesSync()[0];
+	let dBusProxyWrapper = Gio.DBusProxy.makeProxyWrapper(dBusInterface); let start_time = new Date().getTime();log("mpris-label - -----------------------------------------------");
+	let dBusProxy = dBusProxyWrapper(Gio.DBus.session,"org.freedesktop.DBus","/org/freedesktop/DBus");end_time = new Date().getTime(); step = end_time - start_time; log("mpris-label - dBusList: "+step+"ms");
+	let dBusList = dBusProxy.ListNamesSync()[0];end_time = new Date().getTime();
 	return dBusList.filter(element => element.startsWith("org.mpris.MediaPlayer2"));
 }
 
 var getPlayerStatus = function getPlayerStatus(playerAddress) {
-	let statusWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);
-	let statusProxy = statusWrapper(Gio.DBus.session,playerAddress, "/org/mpris/MediaPlayer2");
+	let statusWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);let start_time = new Date().getTime();
+	let statusProxy = statusWrapper(Gio.DBus.session,playerAddress, "/org/mpris/MediaPlayer2");end_time = new Date().getTime(); step = end_time - start_time; log("mpris-label - playbackStatus:("+playerAddress.substring(23)+"): "+step+"ms");
 	return statusProxy.PlaybackStatus;
 }
 
 var getMetadata = function getMetadata(address,field){//could we split this function to source metadata array from DBus only once and split the string separately?
-		let metadataWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);
-		let metadataProxy = metadataWrapper(Gio.DBus.session,address, "/org/mpris/MediaPlayer2");
 		let metadataField = "";
 		if(field == "")
 			return metadataField
+		
+		let metadataWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);let start_time = new Date().getTime();
+		let metadataProxy = metadataWrapper(Gio.DBus.session,address, "/org/mpris/MediaPlayer2");end_time = new Date().getTime(); step = end_time - start_time; log("mpris-label - metadata ("+address.substring(23)+"/"+field+"):"+step+"ms");
+
 		try{
 			if(field == "xesam:artist")
 				metadataField = parseMetadataField(metadataProxy.Metadata[field].get_strv()[0]);

--- a/dbus.js
+++ b/dbus.js
@@ -19,24 +19,6 @@ const dBusInterface = `
 	</interface>
 </node>`
 
-const entryInterface = `
-<node>
-        <interface name="org.mpris.MediaPlayer2">
-                <property name="DesktopEntry" type="s" access="read"/>
-        </interface>
-</node>`
-
-var getDesktopEntry = function getDesktopEntry(playerAddress){
-	try {
-		let entryWrapper = Gio.DBusProxy.makeProxyWrapper(entryInterface);
-		let entryProxy = entryWrapper(Gio.DBus.session,playerAddress,"/org/mpris/MediaPlayer2");
-		return entryProxy.DesktopEntry;
-	}
-	catch {
-		return ""
-	}
-}
-
 var getDBusList = function getDBusList(){
 	let dBusProxyWrapper = Gio.DBusProxy.makeProxyWrapper(dBusInterface);
 	let dBusProxy = dBusProxyWrapper(Gio.DBus.session,"org.freedesktop.DBus","/org/freedesktop/DBus");

--- a/extension.js
+++ b/extension.js
@@ -129,7 +129,10 @@ class MprisLabel extends PanelMenu.Button {
 		REFRESH_RATE = this.settings.get_int('refresh-rate');
 		AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 		REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused');
-//log("mpris-label - this.player: "+this.player.address);
+log("mpris-label - -----------------------------------------------");
+if(this.player)
+	log("mpris-label - this.player: "+this.player.address)
+
 		let lastAddress = null;
 		if (this.player)
 			lastAddress = this.player.address
@@ -178,6 +181,10 @@ class MprisLabel extends PanelMenu.Button {
 
 	_updateSetIcon(){
 		SHOW_ICON = this.settings.get_boolean('show-icon');
+		if (this.icon){
+			this.box.remove_child(this.icon);
+			this.icon = null;
+		}		
 
 		if (SHOW_ICON)
 			this._setIcon()
@@ -216,7 +223,9 @@ class MprisLabel extends PanelMenu.Button {
 
 		if (AUTO_SWITCH_TO_MOST_RECENT){
 			if(this.activePlayers.length == 0){
-				this.player = null;
+				if(REMOVE_TEXT_WHEN_PAUSED)
+					this.player = null
+					
 				return;
 			}
 			list = this.activePlayers;
@@ -233,8 +242,9 @@ class MprisLabel extends PanelMenu.Button {
 
 	_setText() {
 		try{
-			if(this.player == null || undefined)
-				this.buttonText.set_text("");
+			if(this.player == null || undefined){
+				this.buttonText.set_text("");log('mpris-label: exited');
+			}
 			else
 				this.buttonText.set_text(this.labelBuilder.buildLabel(this.player,this.activePlayers));
 		}

--- a/extension.js
+++ b/extension.js
@@ -129,7 +129,7 @@ class MprisLabel extends PanelMenu.Button {
 		REFRESH_RATE = this.settings.get_int('refresh-rate');
 		AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 		REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused');
-
+//log("mpris-label - this.player: "+this.player.address);
 		let lastAddress = null;
 		if (this.player)
 			lastAddress = this.player.address
@@ -160,12 +160,14 @@ class MprisLabel extends PanelMenu.Button {
 		if (!this.player)
 			return
 
-		if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus != "Playing"){
-			if(this.labelBuilder.removeTextPausedIsActive(this.player) && this.icon){
-				this.box.remove_child(this.icon);
-				this.icon = null;
+		if (REMOVE_TEXT_WHEN_PAUSED){
+			if (this.player.playbackStatus != "Playing"){
+				if(this.labelBuilder.removeTextPausedIsActive(this.player) && this.icon){
+					this.box.remove_child(this.icon);
+					this.icon = null;
+				}
+				return
 			}
-			return
 		}
 
 		this.icon = this.player.icon
@@ -195,8 +197,9 @@ class MprisLabel extends PanelMenu.Button {
 		let newPlayers = dBusList.filter(element => !addresses.includes(element));
 		newPlayers.forEach(element => this.playerList.push(new Player(element)));
 
-		this.activePlayers = this.playerList.filter(element => element.playbackStatus == "Playing");
-        }
+		if (AUTO_SWITCH_TO_MOST_RECENT)
+			this.activePlayers = this.playerList.filter(element => element.playbackStatus == "Playing")
+	}
 
 	_pickPlayer(){
 		if(this.playerList.length == 0){
@@ -264,11 +267,11 @@ class Player {
 		this.address = address;
 		this.statusTimestamp = new Date().getTime();
 		this.icon = getIcon(address);
-		if(REMOVE_TEXT_WHEN_PAUSED)
+		if(REMOVE_TEXT_WHEN_PAUSED || AUTO_SWITCH_TO_MOST_RECENT)
 			this.playbackStatus = getPlayerStatus(address)
 	}
 	update(){
-		if(REMOVE_TEXT_WHEN_PAUSED){
+		if(REMOVE_TEXT_WHEN_PAUSED || AUTO_SWITCH_TO_MOST_RECENT){
 			let playbackStatus = getPlayerStatus(this.address);
 
 			if(this.playbackStatus != playbackStatus){

--- a/extension.js
+++ b/extension.js
@@ -130,24 +130,10 @@ class MprisLabel extends PanelMenu.Button {
 		AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 		REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused');
 log("mpris-label - -----------------------------------------------");
-if(this.player)
-	log("mpris-label - this.player: "+this.player.address)
-
-		let lastAddress = null;
-		if (this.player)
-			lastAddress = this.player.address
-
 		this._updatePlayerList();
 		this._pickPlayer();
 		this._setText();
-
-		let newAddress = null;
-		if (this.player)
-			newAddress = this.player.address
-
-		if ( newAddress != lastAddress )
-			this._updateSetIcon()
-
+		this._setIcon();
 		this._removeTimeout();
 		
 		this._timeout = Mainloop.timeout_add(REFRESH_RATE, Lang.bind(this, this._refresh));
@@ -242,9 +228,8 @@ if(this.player)
 
 	_setText() {
 		try{
-			if(this.player == null || undefined){
-				this.buttonText.set_text("");log('mpris-label: exited');
-			}
+			if(this.player == null || undefined)
+				this.buttonText.set_text("")
 			else
 				this.buttonText.set_text(this.labelBuilder.buildLabel(this.player,this.activePlayers));
 		}

--- a/extension.js
+++ b/extension.js
@@ -262,16 +262,19 @@ class MprisLabel extends PanelMenu.Button {
 class Player {
 	constructor(address){
 		this.address = address;
-		this.playbackStatus = getPlayerStatus(address);
 		this.statusTimestamp = new Date().getTime();
 		this.icon = getIcon(address);
+		if(REMOVE_TEXT_WHEN_PAUSED)
+			this.playbackStatus = getPlayerStatus(address)
 	}
 	update(){
-		let playbackStatus = getPlayerStatus(this.address);
+		if(REMOVE_TEXT_WHEN_PAUSED){
+			let playbackStatus = getPlayerStatus(this.address);
 
-		if(this.playbackStatus != playbackStatus){
-			this.playbackStatus = playbackStatus;
-			this.statusTimestamp = new Date().getTime();
+			if(this.playbackStatus != playbackStatus){
+				this.playbackStatus = playbackStatus;
+				this.statusTimestamp = new Date().getTime();
+			}
 		}
 	}
 }

--- a/label.js
+++ b/label.js
@@ -2,7 +2,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
 
-const {getMetadata,getPlayerMetadata} = CurrentExtension.imports.dbus;
+const {getMetadata} = CurrentExtension.imports.dbus;
 
 let MAX_STRING_LENGTH,BUTTON_PLACEHOLDER,REMOVE_REMASTER_TEXT,
 	DIVIDER_STRING,FIRST_FIELD,SECOND_FIELD,LAST_FIELD,

--- a/label.js
+++ b/label.js
@@ -2,7 +2,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
 
-const {getMetadata} = CurrentExtension.imports.dbus;
+const {getMetadata,getPlayerMetadata} = CurrentExtension.imports.dbus;
 
 let MAX_STRING_LENGTH,BUTTON_PLACEHOLDER,REMOVE_REMASTER_TEXT,
 	DIVIDER_STRING,FIRST_FIELD,SECOND_FIELD,LAST_FIELD,


### PR DESCRIPTION
attempt to minimise quantity of Mpris requests to minimise system slowdowns with certain offending mpris sources. Note that this is very much work in progress.

TODO: 
- minimised calls to mpris source whenever the data is not in use (e.g. playbackStatus currently called even on non-active source) - ongoing
- split getMetadata(address,field) into getMetadata(address) and getField(field) in order to only request the Metadata from the mpris source once per cycle - could you please help on this? I tried but failed miserably...
- dynamically monitor reponse time and increase refresh-rate accordingly and/or disable AUTO_SWITCH_TO_MOST_RECENT & REMOVE_TEXT_WHEN_PAUSED - pending