### PR TITLE
update to icon padding mechanism

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -63,15 +63,16 @@ class MprisLabel extends PanelMenu.Button {
 	}
 
 	_onPaddingChanged(){
-		const LEFT_PADDING = this.settings.get_int('left-padding');
+		const ICON_PLACE = this.settings.get_string('show-icon');
+		let LEFT_PADDING = this.settings.get_int('left-padding');
 		let RIGHT_PADDING = this.settings.get_int('right-padding');
 		const SHOW_ICON = this.settings.get_string('show-icon');
 
 		if(SHOW_ICON){
-			if (RIGHT_PADDING < 5)
-				RIGHT_PADDING = 0
+			if (ICON_PLACE == "right")
+				RIGHT_PADDING = Math.max(0,RIGHT_PADDING - 5)
 			else
-				RIGHT_PADDING = RIGHT_PADDING - 5
+				LEFT_PADDING = Math.max(0,LEFT_PADDING - 5)
 		}
 
 		this.box.set_style("padding-left: " + LEFT_PADDING + "px;"

--- a/icons.js
+++ b/icons.js
@@ -1,15 +1,23 @@
 const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const Config = imports.misc.config;
+const ExtensionUtils = imports.misc.extensionUtils;
 
 var getIcon = function getIcon(playerAddress){
+	const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
+	const ICON_PLACE = settings.get_string('show-icon');
+
 	let icon_left_padding = 0;
+	let icon_right_padding = 0;
 	if (Config.PACKAGE_VERSION.startsWith("3."))
-		icon_left_padding = 3
+		if (ICON_PLACE == "right")
+			icon_left_padding = 3
+		else if (ICON_PLACE == "left")
+			icon_right_padding = 3
 
 		let icon = new St.Icon({
 		style_class: 'system-status-icon',
 		fallback_icon_name: 'audio-volume-high',
-		style: "padding-left: " + icon_left_padding + "px;padding-right: 0px;"
+		style: "padding-left: " + icon_left_padding + "px;padding-right: " + icon_right_padding + "px;"
 	});
 
 	if(playerAddress == null | undefined)

--- a/prefs.js
+++ b/prefs.js
@@ -238,7 +238,7 @@ function buildPrefsWidget() {
         showIconComboBox.append(showIconOptions[option],option);
     }
 
-    showIconComboBox.set_active(options.indexOf(settings.get_string('show-icon')));
+    showIconComboBox.set_active_id(settings.get_string('show-icon'));
     showIconComboBox.connect('changed',comboBoxSetString.bind(this,'show-icon',showIconComboBox));
     prefsWidget.attach(showIconComboBox, 1, 14, 1, 1);
 
@@ -283,6 +283,6 @@ function buildPrefsWidget() {
     settings.bind('remove-text-when-paused',removePausedTextSwitch,'active',Gio.SettingsBindFlags.DEFAULT);
     settings.bind('remove-text-paused-delay',removePausedTextDelayEntry,'value',Gio.SettingsBindFlags.DEFAULT);
     settings.bind('auto-switch-to-most-recent',autoSwitchToMostRecentSwitch,'active',Gio.SettingsBindFlags.DEFAULT);
-    settings.bind('show-icon',showIconComboBox,'active',Gio.SettingsBindFlags.DEFAULT);
+    settings.bind('show-icon',showIconComboBox,'text',Gio.SettingsBindFlags.DEFAULT);
     return prefsWidget;
 }


### PR DESCRIPTION
Hi, minor issue but I noticed that the padding didn't quite work when the icon is on the left. I took the opportunity to rewrite the adjustment to keep things concise as it was basically coding the Max function.

Also, the icon location wasn't loaded properly when opening the Settings so I fixed that too.