### PR TITLE
Implement Menu for player selection

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -94,7 +94,6 @@ class MprisLabel extends PanelMenu.Button {
 			new_channels.push(Math.round((channel[0] + channel[1]) / 2));
 		});
 
-		log(new_channels);
 		let mixedColor = Clutter.Color.new(new_channels[0],new_channels[1],new_channels[2],new_channels[3]);
 		let color_str = mixedColor.to_string();
 		this.unfocusColor = color_str.substring(0,7); //ignore alpha channel

--- a/extension.js
+++ b/extension.js
@@ -5,7 +5,6 @@ const {Clutter,Gio,GLib,GObject,St} = imports.gi;
 const Mainloop = imports.mainloop;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
-const Lang = imports.lang;
 
 const { Players } = CurrentExtension.imports.players;
 const { buildLabel } = CurrentExtension.imports.label;
@@ -185,7 +184,6 @@ class MprisLabel extends PanelMenu.Button {
 		this.player = this.players.pick();
 		this._setText();
 		this._setIcon();
-		//this._build_menu();
 		this._removeTimeout();
 
 		this._timeout = Mainloop.timeout_add(REFRESH_RATE, this._refresh.bind(this));

--- a/extension.js
+++ b/extension.js
@@ -112,13 +112,13 @@ class MprisLabel extends PanelMenu.Button {
 		this.players.list.forEach(player => {
 			let settingsMenuItem = new PopupMenu.PopupMenuItem(player.shortname);
 
+			if (AUTO_SWITCH_TO_MOST_RECENT){
+				settingsMenuItem.label.set_style('font-style:italic');
+				settingsMenuItem.set_style('color:#7f7f7f')
+			}
+
 			//if item is active player, include DOT if auto mode, CHECK if manual mode
 			if (this.player) {
-				if (AUTO_SWITCH_TO_MOST_RECENT){
-					settingsMenuItem.label.set_style('font-style:italic');
-					settingsMenuItem.set_style('color:#7f7f7f')
-				}
-
 				if (this.player.address ==  player.address) {
 					if (AUTO_SWITCH_TO_MOST_RECENT)
 						settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)

--- a/extension.js
+++ b/extension.js
@@ -135,11 +135,6 @@ class MprisLabel extends PanelMenu.Button {
 
 				this.players.selected = player; //this.player should sync with this on the next refresh
 				this._refresh();                //so let's refresh right away
-				if (AUTO_SWITCH_TO_MOST_RECENT)
-					this.settings.set_boolean('auto-switch-to-most-recent',false);
-
-				this.players.selected = player;	//this.player should sync with this on the next refresh
-				this._refresh()					//so let's refresh right away
 			});
 
 			this.menu.addMenuItem(settingsMenuItem);

--- a/extension.js
+++ b/extension.js
@@ -99,7 +99,7 @@ class MprisLabel extends PanelMenu.Button {
 		}
 	}
 
-	_buildMenu(){ //https://gjs.guide/extensions/topics/popup-menu.html#popupmenubase
+	_buildMenu(){
 		const REPOSITION_ON_BUTTON_PRESS = this.settings.get_boolean('reposition-on-button-press');
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 
@@ -138,7 +138,7 @@ class MprisLabel extends PanelMenu.Button {
 		if (this.players.list.length > 0){
 			let settingsMenuItem = new PopupMenu.PopupMenuItem('Switch Automatically');
 			if (AUTO_SWITCH_TO_MOST_RECENT) {
-				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);// Ornaments: NONE,DOT,CHECK,HIDDEN
+				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);
 				settingsMenuItem.label.set_style('font-weight:bold');
 			}
 

--- a/extension.js
+++ b/extension.js
@@ -72,20 +72,17 @@ class MprisLabel extends PanelMenu.Button {
 		if (REPOSITION_ON_BUTTON_PRESS)
 			this._updateTrayPosition() //force tray position update on button press
 
-		this.menu.removeAll(); //start by deleting everything if required
+		this.menu.removeAll(); //start by deleting everything
 
-		// Select Player selection Menu
+	//player selection submenu:
 		this.players.list.forEach(player => {
-			let source_name = player.shortname;
-		
-			let settingsMenuItem = new PopupMenu.PopupMenuItem(source_name);
-			//include check to see if item is active player and include DOT if applicable (Auto mode) or CHECK (Manual mode)
-			if (AUTO_SWITCH_TO_MOST_RECENT)
-				settingsMenuItem.label.set_style('font-style:italic')
+			let settingsMenuItem = new PopupMenu.PopupMenuItem(player.shortname);
 
+			//if item is active player, include DOT if auto mode, CHECK if manual mode
 			if (this.player.address ==  player.address) {
 				if (AUTO_SWITCH_TO_MOST_RECENT){
 					settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)
+					settingsMenuItem.label.set_style('font-style:italic')
 				}
 				else {
 					settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK)
@@ -93,12 +90,7 @@ class MprisLabel extends PanelMenu.Button {
 				}
 			}
 
-			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerManual)); //works - replaced with version below
 			settingsMenuItem.connect('activate', (item, event) => {
-				//item.destroy();//works (for info) - not needed
-				//item.label.clutter_text.set_text("Clicked"); //works - not used but kept for future reference
-				// insert code to swith to set 'auto-switch-to-most-recent' to false
-
 				this.players.selected = player; //this.player should sync with this on the next refresh
 				this._refresh();                //so let's refresh right away
 
@@ -106,8 +98,8 @@ class MprisLabel extends PanelMenu.Button {
 			this.menu.addMenuItem(settingsMenuItem);
 		});
 
-		//Add entry to Auto mode at bottom
-		if (this.players.list.length>0){
+	//automode entry:
+		if (this.players.list.length > 0){
 			let settingsMenuItem = new PopupMenu.PopupMenuItem('Switch Automatically');
 			if (AUTO_SWITCH_TO_MOST_RECENT) {
 				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);//Ornaments: NONE: 0, DOT: 1, CHECK: 2, HIDDEN: 3
@@ -120,11 +112,10 @@ class MprisLabel extends PanelMenu.Button {
 				log("mpris label - selecting player automatically");
 				//set 'auto-switch-to-most-recent' to true
 			});
-			//separator
-			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem()); //add separator
 		}
 
-		//settings shortcut
+	//settings shortcut:
 		this.menu.addAction(_('Settings'), () => ExtensionUtils.openPrefs());
 	}
 

--- a/extension.js
+++ b/extension.js
@@ -118,7 +118,6 @@ class MprisLabel extends PanelMenu.Button {
 				let bg = themeNode.get_background_color();
 				let color_str = mix(fg,bg).to_string();
 				color_str = color_str.substring(0,7); //ignore alpha channel
-				log(color_str);
 
 				settingsMenuItem.label.set_style('font-style:italic');
 				settingsMenuItem.set_style('color:' + color_str);

--- a/extension.js
+++ b/extension.js
@@ -65,6 +65,40 @@ class MprisLabel extends PanelMenu.Button {
 		this._refresh();
 	}
 
+	_onPaddingChanged(){
+		const ICON_PLACE = this.settings.get_string('show-icon');
+		let LEFT_PADDING = this.settings.get_int('left-padding');
+		let RIGHT_PADDING = this.settings.get_int('right-padding');
+		const SHOW_ICON = this.settings.get_string('show-icon');
+
+		if(SHOW_ICON){
+			if (ICON_PLACE == "right")
+				RIGHT_PADDING = Math.max(0,RIGHT_PADDING - 5)
+			else
+				LEFT_PADDING = Math.max(0,LEFT_PADDING - 5)
+		}
+
+		this.box.set_style("padding-left: " + LEFT_PADDING + "px;"
+			+ "padding-right: " + RIGHT_PADDING  + "px; ");
+	}
+
+	_updateTrayPosition(){
+		const EXTENSION_PLACE = this.settings.get_string('extension-place');
+		const EXTENSION_INDEX = this.settings.get_int('extension-index');
+
+		this.container.get_parent().remove_child(this.container);
+
+		if(EXTENSION_PLACE == "left"){
+			Main.panel._leftBox.insert_child_at_index(this.container, EXTENSION_INDEX);
+		}
+		else if(EXTENSION_PLACE == "center"){
+			Main.panel._centerBox.insert_child_at_index(this.container, EXTENSION_INDEX);
+		}
+		else if(EXTENSION_PLACE == "right"){
+			Main.panel._rightBox.insert_child_at_index(this.container, EXTENSION_INDEX);
+		}
+	}
+
 	_buildMenu(){ //https://gjs.guide/extensions/topics/popup-menu.html#popupmenubase
 		const REPOSITION_ON_BUTTON_PRESS = this.settings.get_boolean('reposition-on-button-press');
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
@@ -117,40 +151,6 @@ class MprisLabel extends PanelMenu.Button {
 
 	//settings shortcut:
 		this.menu.addAction(_('Settings'), () => ExtensionUtils.openPrefs());
-	}
-
-	_onPaddingChanged(){
-		const ICON_PLACE = this.settings.get_string('show-icon');
-		let LEFT_PADDING = this.settings.get_int('left-padding');
-		let RIGHT_PADDING = this.settings.get_int('right-padding');
-		const SHOW_ICON = this.settings.get_string('show-icon');
-
-		if(SHOW_ICON){
-			if (ICON_PLACE == "right")
-				RIGHT_PADDING = Math.max(0,RIGHT_PADDING - 5)
-			else
-				LEFT_PADDING = Math.max(0,LEFT_PADDING - 5)
-		}
-
-		this.box.set_style("padding-left: " + LEFT_PADDING + "px;"
-			+ "padding-right: " + RIGHT_PADDING  + "px; ");
-	}
-
-	_updateTrayPosition(){
-		const EXTENSION_PLACE = this.settings.get_string('extension-place');
-		const EXTENSION_INDEX = this.settings.get_int('extension-index');
-
-		this.container.get_parent().remove_child(this.container);
-
-		if(EXTENSION_PLACE == "left"){
-			Main.panel._leftBox.insert_child_at_index(this.container, EXTENSION_INDEX);
-		}
-		else if(EXTENSION_PLACE == "center"){
-			Main.panel._centerBox.insert_child_at_index(this.container, EXTENSION_INDEX);
-		}
-		else if(EXTENSION_PLACE == "right"){
-			Main.panel._rightBox.insert_child_at_index(this.container, EXTENSION_INDEX);
-		}
 	}
 
 	_refresh() {

--- a/extension.js
+++ b/extension.js
@@ -86,14 +86,11 @@ class MprisLabel extends PanelMenu.Button {
 
 		// Select Player selection Menu
 		list.forEach((player,index)=>{
-			let source_name = list[index].address.replace('org.mpris.MediaPlayer2.','');
-			source_name = source_name.replace(/\.instance.*/g,'');
-			source_name = source_name.charAt(0).toUpperCase() + source_name.slice(1);//Capitalise first letter
-			//log(Date().substring(16,24)+' gnome-mpris-label/extension.js: '+index+': '+list[index].address+' / pretty name: '+source_name);
-			
+			let source_name = list[index].name;
+		
 			let settingsMenuItem = new PopupMenu.PopupMenuItem(source_name);
+			//include check to see if item is active player and include DOT if applicable (Auto mode) or CHECK (Manual mode)
 			if (AUTO_SWITCH_TO_MOST_RECENT) settingsMenuItem.setOrnament(PopupMenu.Ornament.NONE);
-			//include check to see if item is active player and include DOT if applicable
 
 			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerManual)); //works - replaced with version below
 			settingsMenuItem.connect('activate', (item, event) => {
@@ -108,7 +105,8 @@ class MprisLabel extends PanelMenu.Button {
 
 		if (this.players.list.length>0){
 			let settingsMenuItem = new PopupMenu.PopupMenuItem('Auto');
-			if (AUTO_SWITCH_TO_MOST_RECENT) settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT);
+			if (AUTO_SWITCH_TO_MOST_RECENT) settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);//Ornaments: NONE: 0, DOT: 1, CHECK: 2, HIDDEN: 3
+		
 			this.menu.addMenuItem(settingsMenuItem);
 			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerAuto));  //works - replaced with version below
 			settingsMenuItem.connect('activate', () =>{

--- a/extension.js
+++ b/extension.js
@@ -113,18 +113,20 @@ class MprisLabel extends PanelMenu.Button {
 			let settingsMenuItem = new PopupMenu.PopupMenuItem(player.shortname);
 
 			//if item is active player, include DOT if auto mode, CHECK if manual mode
-			if (this.player.address ==  player.address) {
-				if (AUTO_SWITCH_TO_MOST_RECENT){
-					settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)
-					settingsMenuItem.label.set_style('font-style:italic')
-				}
-				else {
-					settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK)
-					settingsMenuItem.label.set_style('font-weight:bold');
+			if (this.player) {
+				if (this.player.address ==  player.address) {
+					if (AUTO_SWITCH_TO_MOST_RECENT){
+						settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT);
+						settingsMenuItem.label.set_style('font-style:italic');
+					}
+					else {
+						settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);
+						settingsMenuItem.label.set_style('font-weight:bold');
+					}
 				}
 			}
 
-			settingsMenuItem.connect('activate', (item, event) => {
+			settingsMenuItem.connect('activate', () => {
 				this.players.selected = player; //this.player should sync with this on the next refresh
 				this._refresh();                //so let's refresh right away
 
@@ -136,15 +138,13 @@ class MprisLabel extends PanelMenu.Button {
 		if (this.players.list.length > 0){
 			let settingsMenuItem = new PopupMenu.PopupMenuItem('Switch Automatically');
 			if (AUTO_SWITCH_TO_MOST_RECENT) {
-				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);//Ornaments: NONE: 0, DOT: 1, CHECK: 2, HIDDEN: 3
+				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);// Ornaments: NONE,DOT,CHECK,HIDDEN
 				settingsMenuItem.label.set_style('font-weight:bold');
 			}
 
 			this.menu.addMenuItem(settingsMenuItem);
-			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerAuto));  //works - replaced with version below
 			settingsMenuItem.connect('activate', () =>{
-				log("mpris label - selecting player automatically");
-				//set 'auto-switch-to-most-recent' to true
+				this.settings.set_boolean('auto-switch-to-most-recent',!AUTO_SWITCH_TO_MOST_RECENT);
 			});
 			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem()); //add separator
 		}

--- a/extension.js
+++ b/extension.js
@@ -67,6 +67,10 @@ class MprisLabel extends PanelMenu.Button {
 	}
 
 	_build_menu(){
+		const REPOSITION_ON_BUTTON_PRESS = this.settings.get_boolean('reposition-on-button-press');
+		if (REPOSITION_ON_BUTTON_PRESS)
+			this._updateTrayPosition() //force tray position update on button press
+
 		//https://gjs.guide/extensions/topics/popup-menu.html#popupmenubase
 		this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
@@ -92,7 +96,6 @@ class MprisLabel extends PanelMenu.Button {
 			if (selected_player.address ==  list[index].address) {
 				if (AUTO_SWITCH_TO_MOST_RECENT){
 					settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)
-					
 				}
 				else {
 					settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK)
@@ -102,11 +105,15 @@ class MprisLabel extends PanelMenu.Button {
 
 			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerManual)); //works - replaced with version below
 			settingsMenuItem.connect('activate', (item, event) => {
-				log(Date().substring(16,24)+' gnome-mpris-label/extension.js: Item was pressed! ');
+				log(Date().substring(16,24)+' gnome-mpris-label/extension.js: Item '+index+' was pressed! ');
 				//item.destroy();//works (for info) - not needed
-				item.label.clutter_text.set_text("Clicked"); //works - change Label text but will be overwritten on next refresh
+				//item.label.clutter_text.set_text("Clicked"); //works - not used but kept for future reference
 				// insert code to swith to set 'auto-switch-to-most-recent' to false
+
 				// insert code to make selected player the active one
+				if (! AUTO_SWITCH_TO_MOST_RECENT)
+					this._onButtonPressed(index)
+
 			});
 			this.menu.addMenuItem(settingsMenuItem);
 		});
@@ -167,14 +174,9 @@ class MprisLabel extends PanelMenu.Button {
 		}
 	}
 
-	_onButtonPressed(){
+	_onButtonPressed(index){
 		this.player = this.players.next();
-		this._setIcon();
-
-		const REPOSITION_ON_BUTTON_PRESS = this.settings.get_boolean('reposition-on-button-press');
-
-		if (REPOSITION_ON_BUTTON_PRESS)
-			this._updateTrayPosition(); //force tray position update on button press
+		this.refresh();
 	}
 
 	_refresh() {

--- a/extension.js
+++ b/extension.js
@@ -114,14 +114,17 @@ class MprisLabel extends PanelMenu.Button {
 
 			//if item is active player, include DOT if auto mode, CHECK if manual mode
 			if (this.player) {
+				if (AUTO_SWITCH_TO_MOST_RECENT){
+					settingsMenuItem.label.set_style('font-style:italic');
+					settingsMenuItem.set_style('color:#7f7f7f')
+				}
+
 				if (this.player.address ==  player.address) {
-					if (AUTO_SWITCH_TO_MOST_RECENT){
-						settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT);
-						settingsMenuItem.label.set_style('font-style:italic');
-					}
+					if (AUTO_SWITCH_TO_MOST_RECENT)
+						settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)
 					else {
 						settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);
-						settingsMenuItem.label.set_style('font-weight:bold');
+						settingsMenuItem.label.set_style('font-weight:bold')
 					}
 				}
 			}
@@ -132,6 +135,11 @@ class MprisLabel extends PanelMenu.Button {
 
 				this.players.selected = player; //this.player should sync with this on the next refresh
 				this._refresh();                //so let's refresh right away
+				if (AUTO_SWITCH_TO_MOST_RECENT)
+					this.settings.set_boolean('auto-switch-to-most-recent',false);
+
+				this.players.selected = player;	//this.player should sync with this on the next refresh
+				this._refresh()					//so let's refresh right away
 			});
 
 			this.menu.addMenuItem(settingsMenuItem);

--- a/extension.js
+++ b/extension.js
@@ -51,8 +51,6 @@ class MprisLabel extends PanelMenu.Button {
 
 		this.players = new Players();
 
-		log("\n----------------------------------------");log(Date().substring(16,24)+" mpris label: buiding menu");
-
 		//this.connect('button-press-event',this._onButtonPressed.bind(this)); //replaced by menu
 
 		this.settings.connect('changed::left-padding',this._onPaddingChanged.bind(this));
@@ -76,21 +74,31 @@ class MprisLabel extends PanelMenu.Button {
 		//start by deleting everything if required
 		this.menu.removeAll();//works
 
-		//loking for a way to get info on current active player
-		//let this.current_player = this.players.pick();
-		//log(Date().substring(16,24)+' gnome-mpris-label/extension.js: current player - '+this.current_player.address);
+		//get info on current active player
+		let selected_player = this.players.selected;
 
 		//get list of sources
 		let list = this.players.list;
-		//log(Date().substring(16,24)+' gnome-mpris-label/extension.js: list length - '+list.length);
 
 		// Select Player selection Menu
 		list.forEach((player,index)=>{
-			let source_name = list[index].name;
+			let source_name = list[index].shortname;
 		
 			let settingsMenuItem = new PopupMenu.PopupMenuItem(source_name);
 			//include check to see if item is active player and include DOT if applicable (Auto mode) or CHECK (Manual mode)
-			if (AUTO_SWITCH_TO_MOST_RECENT) settingsMenuItem.setOrnament(PopupMenu.Ornament.NONE);
+			if (AUTO_SWITCH_TO_MOST_RECENT)
+				settingsMenuItem.label.set_style('font-style:italic')
+
+			if (selected_player.address ==  list[index].address) {
+				if (AUTO_SWITCH_TO_MOST_RECENT){
+					settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)
+					
+				}
+				else {
+					settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK)
+					settingsMenuItem.label.set_style('font-weight:bold');
+				}
+			}
 
 			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerManual)); //works - replaced with version below
 			settingsMenuItem.connect('activate', (item, event) => {
@@ -103,10 +111,14 @@ class MprisLabel extends PanelMenu.Button {
 			this.menu.addMenuItem(settingsMenuItem);
 		});
 
+		//Add entry to Auto mode at bottom
 		if (this.players.list.length>0){
 			let settingsMenuItem = new PopupMenu.PopupMenuItem('Auto');
-			if (AUTO_SWITCH_TO_MOST_RECENT) settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);//Ornaments: NONE: 0, DOT: 1, CHECK: 2, HIDDEN: 3
-		
+			if (AUTO_SWITCH_TO_MOST_RECENT) {
+				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);//Ornaments: NONE: 0, DOT: 1, CHECK: 2, HIDDEN: 3
+				settingsMenuItem.label.set_style('font-weight:bold');
+			}
+
 			this.menu.addMenuItem(settingsMenuItem);
 			//settingsMenuItem.connect('activate', Lang.bind(this, this._selectPlayerAuto));  //works - replaced with version below
 			settingsMenuItem.connect('activate', () =>{
@@ -120,16 +132,6 @@ class MprisLabel extends PanelMenu.Button {
 		//settings shortcut
 		this.menu.addAction(_('Settings'), () => ExtensionUtils.openPrefs());
 	}
-
-	// _selectPlayerManual(){
-	// 	//this.settings.set_boolean('auto-switch-to-most-recent') = false; //doesnt' work
-	// 	log("mpris label - selecting player manually");
-	// }
-
-	// _selectPlayerAuto(){
-	// 	//this.settings.set_boolean('auto-switch-to-most-recent') = true; //doesnt' work
-	// 	log("mpris label - selecting player automatically");
-	// }
 
 	_onPaddingChanged(){
 		const ICON_PLACE = this.settings.get_string('show-icon');

--- a/extension.js
+++ b/extension.js
@@ -120,7 +120,7 @@ class MprisLabel extends PanelMenu.Button {
 
 		//Add entry to Auto mode at bottom
 		if (this.players.list.length>0){
-			let settingsMenuItem = new PopupMenu.PopupMenuItem('Auto');
+			let settingsMenuItem = new PopupMenu.PopupMenuItem('Switch Automatically');
 			if (AUTO_SWITCH_TO_MOST_RECENT) {
 				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);//Ornaments: NONE: 0, DOT: 1, CHECK: 2, HIDDEN: 3
 				settingsMenuItem.label.set_style('font-weight:bold');

--- a/extension.js
+++ b/extension.js
@@ -127,10 +127,13 @@ class MprisLabel extends PanelMenu.Button {
 			}
 
 			settingsMenuItem.connect('activate', () => {
+				if (AUTO_SWITCH_TO_MOST_RECENT)
+					this.settings.set_boolean('auto-switch-to-most-recent',false);
+
 				this.players.selected = player; //this.player should sync with this on the next refresh
 				this._refresh();                //so let's refresh right away
-
 			});
+
 			this.menu.addMenuItem(settingsMenuItem);
 		});
 

--- a/extension.js
+++ b/extension.js
@@ -51,7 +51,7 @@ class MprisLabel extends PanelMenu.Button {
 
 		this.players = new Players();
 
-		//this.connect('button-press-event',this._onButtonPressed.bind(this)); //replaced by menu
+		this.connect('button-press-event',this._build_menu.bind(this));
 
 		this.settings.connect('changed::left-padding',this._onPaddingChanged.bind(this));
 		this.settings.connect('changed::right-padding',this._onPaddingChanged.bind(this));
@@ -183,7 +183,7 @@ class MprisLabel extends PanelMenu.Button {
 		this.player = this.players.pick();
 		this._setText();
 		this._setIcon();
-		this._build_menu();
+		//this._build_menu();
 		this._removeTimeout();
 
 		this._timeout = Mainloop.timeout_add(REFRESH_RATE, this._refresh.bind(this));

--- a/extension.js
+++ b/extension.js
@@ -104,7 +104,7 @@ class MprisLabel extends PanelMenu.Button {
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 
 		if (REPOSITION_ON_BUTTON_PRESS)
-			this._updateTrayPosition() //force tray position update on button press
+			this._updateTrayPosition(); //force tray position update on button press
 
 		this.menu.removeAll(); //start by deleting everything
 
@@ -113,18 +113,25 @@ class MprisLabel extends PanelMenu.Button {
 			let settingsMenuItem = new PopupMenu.PopupMenuItem(player.shortname);
 
 			if (AUTO_SWITCH_TO_MOST_RECENT){
+				let themeNode = this.get_theme_node();
+				let fg = themeNode.get_foreground_color();
+				let bg = themeNode.get_background_color();
+				let color_str = mix(fg,bg).to_string();
+				color_str = color_str.substring(0,7); //ignore alpha channel
+				log(color_str);
+
 				settingsMenuItem.label.set_style('font-style:italic');
-				settingsMenuItem.set_style('color:#7f7f7f')
+				settingsMenuItem.set_style('color:' + color_str);
 			}
 
 			//if item is active player, include DOT if auto mode, CHECK if manual mode
 			if (this.player) {
 				if (this.player.address ==  player.address) {
 					if (AUTO_SWITCH_TO_MOST_RECENT)
-						settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT)
+						settingsMenuItem.setOrnament(PopupMenu.Ornament.DOT);
 					else {
 						settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);
-						settingsMenuItem.label.set_style('font-weight:bold')
+						settingsMenuItem.label.set_style('font-weight:bold');
 					}
 				}
 			}
@@ -227,4 +234,20 @@ class MprisLabel extends PanelMenu.Button {
 		}
 	}
 });
+
+function mix(c1,c2) {
+	//Clutter.Color doesn't have a method for average mixing
+	const reds = [c1.red,c2.red];
+	const greens = [c1.green,c2.green];
+	const blues = [c1.blue,c2.blue];
+	const alpha = [c1.alpha,c2.alpha];
+	const channels = [reds,greens,blues,alpha];
+
+	let new_channels = [];
+	channels.forEach(channel => {
+		new_channels.push(Math.round((channel[0] + channel[1]) / 2));
+	});
+
+	return Clutter.Color.new(new_channels[0],new_channels[1],new_channels[2],new_channels[3])
+}
 

--- a/extension.js
+++ b/extension.js
@@ -50,7 +50,7 @@ class MprisLabel extends PanelMenu.Button {
 
 		this.players = new Players();
 
-		this.connect('button-press-event',this._build_menu.bind(this));
+		this.connect('button-press-event',this._buildMenu.bind(this));
 
 		this.settings.connect('changed::left-padding',this._onPaddingChanged.bind(this));
 		this.settings.connect('changed::right-padding',this._onPaddingChanged.bind(this));
@@ -65,7 +65,7 @@ class MprisLabel extends PanelMenu.Button {
 		this._refresh();
 	}
 
-	_build_menu(){
+	_buildMenu(){
 		const REPOSITION_ON_BUTTON_PRESS = this.settings.get_boolean('reposition-on-button-press');
 		if (REPOSITION_ON_BUTTON_PRESS)
 			this._updateTrayPosition() //force tray position update on button press

--- a/players.js
+++ b/players.js
@@ -65,14 +65,6 @@ var Players = class Players {
 		this.selected = bestChoice;
 		return this.selected
 	}
-	select(index){
-		if(list.length < index || AUTO_SWITCH_TO_MOST_RECENT)
-			return this.selected
-
-		this.selected = list[index];
-
-		return this.selected
-	}
 	next(){
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 

--- a/players.js
+++ b/players.js
@@ -65,6 +65,9 @@ var Players = class Players {
 		this.selected = bestChoice;
 		return this.selected
 	}
+	list(){
+		let list = this.list;
+	}
 	next(){
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 

--- a/players.js
+++ b/players.js
@@ -76,12 +76,6 @@ var Players = class Players {
 
 		return this.selected
 	}
-	list(){
-		let list = this.list
-	}
-	selected(){
-		let selected = this.selected
-	}
 	next(){
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 

--- a/players.js
+++ b/players.js
@@ -66,11 +66,8 @@ var Players = class Players {
 		return this.selected
 	}
 	select(index){
-		let list = this.list;
-
-		if(list.length < index || AUTO_SWITCH_TO_MOST_RECENT) {
+		if(list.length < index || AUTO_SWITCH_TO_MOST_RECENT)
 			return this.selected
-		}
 
 		this.selected = list[index];
 

--- a/players.js
+++ b/players.js
@@ -142,6 +142,11 @@ class Player {
 
 		const proxyWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);
 		this.proxy = proxyWrapper(Gio.DBus.session,this.address, "/org/mpris/MediaPlayer2",this.update.bind(this));
+		
+		let name = address.replace('org.mpris.MediaPlayer2.','');
+		name = name.replace(/\.instance.*/g,'');
+		name = name.charAt(0).toUpperCase() + name.slice(1);//Capitalise first letter
+		this.name = name;
 	}
 	update(){
 		let playbackStatus = this.getStatus();

--- a/players.js
+++ b/players.js
@@ -65,11 +65,22 @@ var Players = class Players {
 		this.selected = bestChoice;
 		return this.selected
 	}
-	list(){
+	select(index){
 		let list = this.list;
+
+		if(list.length < index || AUTO_SWITCH_TO_MOST_RECENT) {
+			return this.selected
+		}
+
+		this.selected = list[index];
+
+		return this.selected
+	}
+	list(){
+		let list = this.list
 	}
 	selected(){
-		let selected = this.selected;
+		let selected = this.selected
 	}
 	next(){
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');

--- a/players.js
+++ b/players.js
@@ -68,6 +68,9 @@ var Players = class Players {
 	list(){
 		let list = this.list;
 	}
+	selected(){
+		let selected = this.selected;
+	}
 	next(){
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 
@@ -143,10 +146,10 @@ class Player {
 		const proxyWrapper = Gio.DBusProxy.makeProxyWrapper(mprisInterface);
 		this.proxy = proxyWrapper(Gio.DBus.session,this.address, "/org/mpris/MediaPlayer2",this.update.bind(this));
 		
-		let name = address.replace('org.mpris.MediaPlayer2.','');
-		name = name.replace(/\.instance.*/g,'');
-		name = name.charAt(0).toUpperCase() + name.slice(1);//Capitalise first letter
-		this.name = name;
+		let shortname = address.replace('org.mpris.MediaPlayer2.','');
+		shortname = shortname.replace(/\.instance.*/g,'');
+		shortname = shortname.charAt(0).toUpperCase() + shortname.slice(1);//Capitalise first letter
+		this.shortname = shortname;
 	}
 	update(){
 		let playbackStatus = this.getStatus();


### PR DESCRIPTION
as per item 4 in Development Roadmap #4 , this is a working version to implement a menu selection for the active player.

Todo List:
- [x] generate menu with list of items
- [x] include link to Settings
- [x] make menu dynamically update based on actual sources
- [x] update menu item formatting to highlight selected/active item Vs other sources (See screenshots below)
- [x] grey out on sources when in Manual mode (instead of italic) to indicate it's info only.
- [x] link grey colour used for source to theme style for non sensitive menu items (or equivalent)
- [x] link item selection event to turn `AUTO_SWITCH_TO_MOST_RECENT` on and off
- [x] link item selection event to actual selection of source (i.e. Clicking Spotify switches the source)
- [ ] ~~move Build_Menu code into separate menu.js file~~
- [ ] check code for edge cases and missing inputs which may make it generate errors/fail (e.g. source disappears while menu is open)
- [x] check compatibility (e.g. on GNOME 3.38, the menu works but the dot doesn't appear)
- [ ] ~~check for impacts/improvements to existing code (e.g. button click to refresh extension position no longer works, new `shortname` item could be used in filter section to remove the address re-formatting lines)~~

known issue:
- [x] Menu is refreshed on each iteration. If an item is highlighted and the mouse left in position, the refresh will be visible as the item will blink as it gets refreshed. This is not visible on other extensions using menus. Need to compare implementation to see how the menu could be updated only on click. Edit: fixed by linking menu generation to mouse click instead of each refresh cycle.

**Auto Selection Mode:** tick for Auto, dot to indicate active source. sources in italic to indicate that they are listed for info only
![image](https://user-images.githubusercontent.com/56710655/215279916-148ae107-32ec-4009-831a-a46fd21c6a3e.png)
**Manual Selection Mode:** tick mark for selected source
![image](https://user-images.githubusercontent.com/56710655/215279962-d66668d0-cd80-4caf-9bde-1d1f0b1b2629.png)