### PR TITLE
Update Broken Player Filtering (new)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -346,8 +346,17 @@ class MprisLabel extends PanelMenu.Button {
 		const REFRESH_RATE = this.settings.get_int('refresh-rate');
 
 		let prevPlayer = this.player;
-		this.players.updateActiveList();
+
+		try {
+			this.players.updateFilterList();
+			this.players.updateActiveList();
+		}
+		catch {
+			; //do nothing
+		}
+
 		this.player = this.players.pick();
+
 		if(this.player != prevPlayer)
 			this._getStream();
 

--- a/players.js
+++ b/players.js
@@ -115,9 +115,6 @@ var Players = class Players {
 		dBusList.forEach(address => this.unfilteredList.push(new Player(address)));
 
 		this.dBusProxy.connectSignal('NameOwnerChanged',this._updateList.bind(this));
-		this.settings.connect('changed::mpris-sources-blacklist',this.updateFilterList.bind(this));
-		this.settings.connect('changed::mpris-sources-whitelist',this.updateFilterList.bind(this));
-		this.settings.connect('changed::use-whitelisted-sources-only',this.updateFilterList.bind(this));
 	}
 	_updateList(proxy, sender, [name,oldOwner,newOwner]){
 		if(name.startsWith("org.mpris.MediaPlayer2")){

--- a/players.js
+++ b/players.js
@@ -150,6 +150,9 @@ var Players = class Players {
 		this.updateActiveList();
 	}
 	updateActiveList(){
+		if (this.unfilteredList)
+			this._filterList()
+
 		let actives = [];
 		this.list.forEach(player => {
 			if(player.playbackStatus == "Playing")

--- a/players.js
+++ b/players.js
@@ -57,6 +57,9 @@ var Players = class Players {
 			return this.selected
 		}
 
+		if(!this.list.includes(this.selected))
+			this.selected = null
+
 		if(this.list.includes(this.selected) && !AUTO_SWITCH_TO_MOST_RECENT)
 			return this.selected
 

--- a/players.js
+++ b/players.js
@@ -115,8 +115,6 @@ var Players = class Players {
 		this.settings.connect('changed::mpris-sources-blacklist',this._filterList.bind(this));
 		this.settings.connect('changed::mpris-sources-whitelist',this._filterList.bind(this));
 		this.settings.connect('changed::use-whitelisted-sources-only',this._filterList.bind(this));
-
-		this._filterList();
 	}
 	_updateList(proxy, sender, [name,oldOwner,newOwner]){
 		if(name.startsWith("org.mpris.MediaPlayer2")){
@@ -127,7 +125,6 @@ var Players = class Players {
 			else if (!newOwner && oldOwner){ //delete player
 				this.unfilteredList = this.unfilteredList.filter(player => player.address != name);
 			}
-			this._filterList();
 		}
 	}
 	_filterList(){
@@ -146,10 +143,11 @@ var Players = class Players {
 
 		if(!USE_WHITELIST && SOURCES_BLACKLIST)
 			this.list = this.unfilteredList.filter(element => !blacklist.includes(element.identity.toLowerCase().replaceAll(' ','')));
-
-		this.updateActiveList();
 	}
 	updateActiveList(){
+		if(this.unfilteredList)
+			this._filterList()
+
 		let actives = [];
 		this.list.forEach(player => {
 			if(player.playbackStatus == "Playing")

--- a/players.js
+++ b/players.js
@@ -150,9 +150,6 @@ var Players = class Players {
 		this.updateActiveList();
 	}
 	updateActiveList(){
-		if (this.unfilteredList)
-			this._filterList()
-
 		let actives = [];
 		this.list.forEach(player => {
 			if(player.playbackStatus == "Playing")

--- a/players.js
+++ b/players.js
@@ -115,9 +115,9 @@ var Players = class Players {
 		dBusList.forEach(address => this.unfilteredList.push(new Player(address)));
 
 		this.dBusProxy.connectSignal('NameOwnerChanged',this._updateList.bind(this));
-		this.settings.connect('changed::mpris-sources-blacklist',this._filterList.bind(this));
-		this.settings.connect('changed::mpris-sources-whitelist',this._filterList.bind(this));
-		this.settings.connect('changed::use-whitelisted-sources-only',this._filterList.bind(this));
+		this.settings.connect('changed::mpris-sources-blacklist',this.updateFilterList.bind(this));
+		this.settings.connect('changed::mpris-sources-whitelist',this.updateFilterList.bind(this));
+		this.settings.connect('changed::use-whitelisted-sources-only',this.updateFilterList.bind(this));
 	}
 	_updateList(proxy, sender, [name,oldOwner,newOwner]){
 		if(name.startsWith("org.mpris.MediaPlayer2")){
@@ -130,7 +130,10 @@ var Players = class Players {
 			}
 		}
 	}
-	_filterList(){
+	updateFilterList(){
+		if(!this.unfilteredList)
+			return
+
 		const SOURCES_BLACKLIST = this.settings.get_string('mpris-sources-blacklist');
 		const SOURCES_WHITELIST = this.settings.get_string('mpris-sources-whitelist');
 		let USE_WHITELIST = this.settings.get_boolean('use-whitelisted-sources-only');
@@ -148,9 +151,6 @@ var Players = class Players {
 			this.list = this.unfilteredList.filter(element => !blacklist.includes(element.identity.toLowerCase().replaceAll(' ','')));
 	}
 	updateActiveList(){
-		if(this.unfilteredList)
-			this._filterList()
-
 		let actives = [];
 		this.list.forEach(player => {
 			if(player.playbackStatus == "Playing")

--- a/players.js
+++ b/players.js
@@ -142,10 +142,10 @@ var Players = class Players {
 		const whitelist = SOURCES_WHITELIST.toLowerCase().replaceAll(' ','').split(',');
 
 		if(USE_WHITELIST && SOURCES_WHITELIST)
-			this.list = this.unfilteredList.filter(element => whitelist.includes(element));
+			this.list = this.unfilteredList.filter(element => whitelist.includes(element.identity.toLowerCase().replaceAll(' ','')));
 
 		if(!USE_WHITELIST && SOURCES_BLACKLIST)
-			this.list = this.unfilteredList.filter(element => !blacklist.includes(element));
+			this.list = this.unfilteredList.filter(element => !blacklist.includes(element.identity.toLowerCase().replaceAll(' ','')));
 
 		this.updateActiveList();
 	}


### PR DESCRIPTION
Follow-up on #32 with separate rebased working branch. This is a testing branch which doesn't yet solve the issue.

As per other PR, player filtering is no longer effective since it occurs before the `identity` information is made available:
`_updateList -> _filterList -> _onEntryProxyReady`

`_filterList` is only called when:
a. An mpris address is added or removed to the dbus list
b. filter options are modified

This in code translates to:
````
this.dBusProxy.connectSignal('NameOwnerChanged',this._updateList.bind(this)); //and the code in _updateList
this.settings.connect('changed::mpris-sources-blacklist',this._filterList.bind(this));
this.settings.connect('changed::mpris-sources-whitelist',this._filterList.bind(this));
this.settings.connect('changed::use-whitelisted-sources-only',this._filterList.bind(this));
````
Which is part of `_initList`