### PR TITLE
Prioritise first icon match (Spot Fix)

### DIFF
--- a/players.js
+++ b/players.js
@@ -202,9 +202,11 @@ class Player {
 		const activeApps = Shell.AppSystem.get_default().get_running();
 
 		let match = matchedEntries[0];
+		let matchFound = false;
 		matchedEntries.forEach(entry => {
 			let playerObject = Shell.AppSystem.get_default().lookup_app(entry);
-			if (activeApps.includes(playerObject)){
+			if (activeApps.includes(playerObject) && !matchFound){
+				matchFound = true;
 				match = entry
 			}
 		});


### PR DESCRIPTION
With regards to isse #33, upon further inspect, due to the inability of the forEach to exit on match, the icon is set based on the last match.

In the case of Spot, if Spotify is open (unlikely by ok...), we get to a situation where `matchedEntries: dev.alextren.Spot.desktop,com.spotify.Client.desktop`. in `_matchRunningApps()`, this the first entry matches a running app, so does the second one which is taken as the correct result.

We could use a `for` loop with a return instead. In this commit, I have instead implemented a `matchFound` flag so when a match is found, no other match is saved. This successfully fixes the issue and on the basis that `matchedEntries` are already ordered but Gnome in order of probability, I believe that it is fair to prioritise the first match. 

I  don' t believe that this introduces any regression but do let me know if you have any comment.