### PR TITLE
Check for container to prevent occasional extension loading failure

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -106,15 +106,16 @@ class MprisLabel extends PanelMenu.Button {
 		const EXTENSION_PLACE = this.settings.get_string('extension-place');
 		const EXTENSION_INDEX = this.settings.get_int('extension-index');
 
-		this.container.get_parent().remove_child(this.container);
+		if (this.container.get_parent())
+			this.container.get_parent().remove_child(this.container);
 
-		if(EXTENSION_PLACE == "left"){
+		if (EXTENSION_PLACE == "left"){
 			Main.panel._leftBox.insert_child_at_index(this.container, EXTENSION_INDEX);
 		}
-		else if(EXTENSION_PLACE == "center"){
+		else if (EXTENSION_PLACE == "center"){
 			Main.panel._centerBox.insert_child_at_index(this.container, EXTENSION_INDEX);
 		}
-		else if(EXTENSION_PLACE == "right"){
+		else if (EXTENSION_PLACE == "right"){
 			Main.panel._rightBox.insert_child_at_index(this.container, EXTENSION_INDEX);
 		}
 	}


### PR DESCRIPTION
as mentioned in [this comment](https://github.com/Moon-0xff/gnome-mpris-label/issues/42#issuecomment-1484000482), I have been getting errors with the extension being unable to loads when testing previous version or order to investigate #42.

Not sure why we never had the issue before but I believe that this check should be included.

also updated the `if ()` to include spaces as per gnome convention.