### PR TITLE
Restore previously focused window after `Open App`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,7 @@ Aditionally:
 - Increases the chance of finding the application icon
 - Adds bindable mouse controls
 - Improves performance (refresh time down from 5-9ms to 1ms or less)
+
+# Upcoming Version
+- Focuses the previously focused window when the 'open app' action is activated
+  and the currently focused window is the player window

--- a/players.js
+++ b/players.js
@@ -263,9 +263,8 @@ class Player {
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
 			let focused_window = global.display.get_focus_window();
-			
+
 			if (this.player_window == null || focused_window != this.player_window){//activate player
-				this.previous_app_window = focused_window;
 				if (this.player_window)//only able to record status once window is known
 					this.player_window_minimized = this.player_window.minimized
 
@@ -274,13 +273,13 @@ class Player {
 				return
 			}
 
-			if (this.previous_app_window){//restore previous window
-				if (this.player_window_minimized)
-					this.player_window.minimize();
-				
-				this.previous_app_window.activate(global.get_current_time());
-				// AltTab.AppSwitcherPopup(); //does nothing
-			}
+			if (this.player_window_minimized)
+				this.player_window.minimize();
+
+			// equivalent to Alt+tab. window to be focused is at the end of the list, just before player and Gnome-shell
+			let windows_list = global.get_window_actors();
+			let app_window = windows_list[windows_list.length - 3].get_meta_window(); 
+			app_window.activate(global.get_current_time());
 		}
 	}
 }

--- a/players.js
+++ b/players.js
@@ -168,7 +168,6 @@ class Player {
 
 		const entryWrapper = Gio.DBusProxy.makeProxyWrapper(entryInterface);
 		this.entryProxy = entryWrapper(Gio.DBus.session,this.address, "/org/mpris/MediaPlayer2",this._onEntryProxyReady.bind(this));
-
 	}
 	_onEntryProxyReady(){
 		this.identity = this.entryProxy.Identity;
@@ -195,6 +194,8 @@ class Player {
 			this.desktopApp = this._matchRunningApps(matchedEntries)
 
 		this.icon = this.getIcon(this.desktopApp);
+
+		this.playerWindow = this._guessAppWindow(this.identity);
 	}
 	_matchRunningApps(matchedEntries){
 		const activeApps = Shell.AppSystem.get_default().get_running();
@@ -262,14 +263,13 @@ class Player {
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
 			let focused_window = global.display.get_focus_window();
-			let player_window = this._guessAppWindow(this.identity);
 
-			if (!player_window)
+			if (!this.playerWindow)
 				return
 
-			if (focused_window == player_window){
-				if (this.player_window_minimized)
-					player_window.minimize();
+			if (focused_window == this.playerWindow){
+				if (this.isWindowMinimized)
+					this.playerWindow.minimize();
 
 				//window to be focused is at the end of the list, just before player and Gnome-shell
 				let windows_list = global.get_window_actors();
@@ -277,7 +277,7 @@ class Player {
 				app_window.activate(global.get_current_time()); //equivalent to Alt+tab
 			}
 			else{
-				this.player_window_minimized = player_window.minimized;
+				this.isWindowMinimized = this.playerWindow.minimized;
 				app.activate();
 			}
 		}

--- a/players.js
+++ b/players.js
@@ -1,6 +1,7 @@
-const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
+const {Clutter,Gio,GLib,GObject,Shell,St,Meta} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
+const altTab = imports.ui.altTab;
 
 const mprisInterface = `
 <node>
@@ -269,10 +270,10 @@ class Player {
 			if (this.player_window_minimized)
 				player_window.minimize();
 
-			//window to be focused is at the end of the list, just before player and Gnome-shell
 			let windows_list = global.get_window_actors();
-			let app_window = windows_list[windows_list.length - 3].get_meta_window();
-			app_window.activate(global.get_current_time()); //equivalent to Alt+tab
+			windows_list = windows_list.filter(element => element.get_meta_window().get_window_type() == 0); //filter out non-normal windows
+			let app_window = windows_list[windows_list.length - 2].get_meta_window(); //window to be focused is at the end of the list, just before player
+			app_window.activate(global.get_current_time());
 		}
 		else{
 			if(this.desktopApp){

--- a/players.js
+++ b/players.js
@@ -279,7 +279,15 @@ class Player {
 	}
 	_guessAppWindow(identity){//secondary best-guess method to match player with window
 		identity = identity.toLowerCase();
-		for (const actor of global.get_window_actors()) {
+		
+		for (const actor of global.get_window_actors()) {//first pass exact match
+			const window = actor.get_meta_window();
+			let wm_class = window.get_wm_class().toLowerCase();
+			if (wm_class == identity)
+				return window;
+		}
+		
+		for (const actor of global.get_window_actors()) {//fallback approximate match
 			const window = actor.get_meta_window();
 			let wm_class = window.get_wm_class().toLowerCase();
 			if (wm_class.includes(identity) | identity.includes(wm_class))

--- a/players.js
+++ b/players.js
@@ -259,24 +259,24 @@ class Player {
 			this.proxy.PreviousRemote()
 	}
 	activatePlayer(){
-		if(this.desktopApp){
-			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
-			let focused_window = global.display.get_focus_window();
-			let player_window = this._guessAppWindow(this.identity);
+		let focused_window = global.display.get_focus_window();
+		let player_window = this._guessAppWindow(this.identity);
 
-			if (!player_window)
-				return
+		if (!player_window)
+			return
 
-			if (focused_window == player_window){
-				if (this.player_window_minimized)
-					player_window.minimize();
+		if (focused_window == player_window){
+			if (this.player_window_minimized)
+				player_window.minimize();
 
-				//window to be focused is at the end of the list, just before player and Gnome-shell
-				let windows_list = global.get_window_actors();
-				let app_window = windows_list[windows_list.length - 3].get_meta_window();
-				app_window.activate(global.get_current_time()); //equivalent to Alt+tab
-			}
-			else{
+			//window to be focused is at the end of the list, just before player and Gnome-shell
+			let windows_list = global.get_window_actors();
+			let app_window = windows_list[windows_list.length - 3].get_meta_window();
+			app_window.activate(global.get_current_time()); //equivalent to Alt+tab
+		}
+		else{
+			if(this.desktopApp){
+				let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
 				this.player_window_minimized = player_window.minimized;
 				app.activate();
 			}

--- a/players.js
+++ b/players.js
@@ -266,14 +266,18 @@ class Player {
 			
 			if (this.player_window == null || focused_window != this.player_window){//activate player
 				this.previous_app_window = focused_window;
+				if (this.player_window)//only able to record status once window is known
+					this.player_window_minimized = this.player_window.minimized
+
 				app.activate();
 				this.player_window = global.display.get_focus_window();
 				return
 			}
 
-			//if player was minimised before activatePlayer, re-minimise it
-			
 			if (this.previous_app_window){//restore previous window
+				if (this.player_window_minimized)
+					this.player_window.minimize();
+				
 				this.previous_app_window.activate(global.get_current_time());
 				// AltTab.AppSwitcherPopup(); //does nothing
 			}

--- a/players.js
+++ b/players.js
@@ -294,7 +294,7 @@ class Player {
 		for (const actor of windows_list) {//fallback approximate match
 			const window = actor.get_meta_window();
 			let wm_class = window.get_wm_class().toLowerCase();
-			if (wm_class.includes(identity) | identity.includes(wm_class))
+			if (wm_class.includes(identity) || identity.includes(wm_class))
 				return window;
 		}
 	}

--- a/players.js
+++ b/players.js
@@ -1,7 +1,7 @@
 const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
-//const AltTab = imports.ui.altTab;
+const AltTab = imports.ui.altTab;
 
 const mprisInterface = `
 <node>
@@ -262,12 +262,12 @@ class Player {
 	activatePlayer(){
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
-			let focused_window = this.getActiveWindow();//get details of the app opened prior
+			let focused_window = global.display.get_focus_window();
 			
 			if (this.player_window == null || focused_window != this.player_window){//activate player
 				this.previous_app_window = focused_window;
 				app.activate();
-				this.player_window = this.getActiveWindow();
+				this.player_window = global.display.get_focus_window();
 				return
 			}
 
@@ -275,18 +275,9 @@ class Player {
 			
 			if (this.previous_app_window){//restore previous window
 				this.previous_app_window.activate(global.get_current_time());
-				// AltTab.AppSwitcherPopup.previousWindow(); //does nothing
+				// AltTab.AppSwitcherPopup(); //does nothing
 			}
 		}
-	}
-	getActiveWindow(){
-		for (const actor of global.get_window_actors()) {
-			const window = actor.get_meta_window();
-			if (window.has_focus())
-				return window;
-		}
-		
-		return null
 	}
 }
 

--- a/players.js
+++ b/players.js
@@ -266,15 +266,15 @@ class Player {
 		if (!playerWindow)
 			return
 
-		if (focusedWindow == playerWindow && this.focusedApp){
+		if (focusedWindow == playerWindow){
 			if (this.playerWindowMinimized)
 				playerWindow.minimize();
 
-			this.focusedApp.activate(global.get_current_time());
+			let apps = Shell.AppSystem.get_default().get_running();
+			apps[1].activate(global.get_current_time());
 		}
 		else{
 			if(this.desktopApp){
-				this.focusedApp = global.display.get_focus_window(); //save focused window
 				this.playerWindowMinimized = playerWindow.minimized;
 				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
 			}

--- a/players.js
+++ b/players.js
@@ -270,6 +270,7 @@ class Player {
 			if (focused_window == player_window){
 				if (this.player_window_minimized)
 					player_window.minimize();
+
 				//window to be focused is at the end of the list, just before player and Gnome-shell
 				let windows_list = global.get_window_actors();
 				let app_window = windows_list[windows_list.length - 3].get_meta_window();

--- a/players.js
+++ b/players.js
@@ -1,7 +1,6 @@
 const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
-const AltTab = imports.ui.altTab;
 
 const mprisInterface = `
 <node>

--- a/players.js
+++ b/players.js
@@ -261,24 +261,18 @@ class Player {
 	activatePlayer(){
 		let focusedWindow = global.display.get_focus_window();
 		let playerWindow = this._guessAppWindow(this.identity);
-		let currentWorkspace = global.workspace_manager.get_active_workspace();
 
 		if (!playerWindow)
 			return
 
 		if (focusedWindow == playerWindow){
-			if (currentWorkspace == this.previousWorkspace){ //go back to last workspace
-				if (this.playerWindowMinimized)
-					playerWindow.minimize();
+			if (this.playerWindowMinimized)
+				playerWindow.minimize();
 
-				this.previousWindow.activate(global.get_current_time());
-			}
-			else if (this.previousWorkspace)//focus window on current workspace
-				this.previousWorkspace.activate(global.get_current_time());
+			this.previousWindow.activate(global.get_current_time());
 		}
 		else{
 			if(this.desktopApp){
-				this.previousWorkspace = currentWorkspace;
 				this.previousWindow = focusedWindow;
 				this.playerWindowMinimized = playerWindow.minimized;
 				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();

--- a/players.js
+++ b/players.js
@@ -268,13 +268,17 @@ class Player {
 				return
 
 			if (focused_window == player_window){
+				if (this.player_window_minimized)
+					player_window.minimize();
 				//window to be focused is at the end of the list, just before player and Gnome-shell
 				let windows_list = global.get_window_actors();
 				let app_window = windows_list[windows_list.length - 3].get_meta_window();
 				app_window.activate(global.get_current_time()); //equivalent to Alt+tab
 			}
-			else
+			else{
+				this.player_window_minimized = player_window.minimized;
 				app.activate();
+			}
 		}
 	}
 	_guessAppWindow(identity){//secondary best-guess method to match player with window

--- a/players.js
+++ b/players.js
@@ -260,7 +260,7 @@ class Player {
 	}
 	activatePlayer(){
 		let focusedWindow = global.display.get_focus_window();
-		let playerWindow = this._guessAppWindow(this.identity);
+		let playerWindow = this._matchAppWindow();
 		let currentWorkspace = global.workspace_manager.get_active_workspace();
 
 		if (!playerWindow)
@@ -281,26 +281,21 @@ class Player {
 				this.previousWorkspace = currentWorkspace;
 				this.previousWindow = focusedWindow;
 				this.playerWindowMinimized = playerWindow.minimized;
-				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
+				playerWindow.activate(global.get_current_time());
 			}
 		}
 	}
-	_guessAppWindow(identity){//secondary best-guess method to match player with window
-		identity = identity.toLowerCase();
+	_matchAppWindow(){//match player with window
+		let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
+		let appPID = app.get_pids();
+
 		let windows_list = global.get_window_actors();
 		windows_list = windows_list.filter(element => element.get_meta_window().get_window_type() == 0); //only keep normal windows
 		
-		for (const actor of windows_list) {//first pass exact match
+		for (const actor of windows_list) {//match window based on pid
 			const window = actor.get_meta_window();
-			let wm_class = window.get_wm_class().toLowerCase();
-			if (wm_class == identity)
-				return window;
-		}
-		
-		for (const actor of windows_list) {//fallback approximate match
-			const window = actor.get_meta_window();
-			let wm_class = window.get_wm_class().toLowerCase();
-			if (wm_class.includes(identity) || identity.includes(wm_class))
+			let windowPID = window.get_pid();
+			if (appPID.includes(windowPID))
 				return window;
 		}
 	}

--- a/players.js
+++ b/players.js
@@ -1,4 +1,4 @@
-const {Clutter,Gio,GLib,GObject,Shell,St,Meta} = imports.gi;
+const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
 

--- a/players.js
+++ b/players.js
@@ -1,6 +1,7 @@
 const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
+const AltTab = imports.ui.altTab;
 
 const mprisInterface = `
 <node>
@@ -261,8 +262,31 @@ class Player {
 	activatePlayer(){
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
-			app.activate();
+			this.focused_window = this.getActiveWindow();//get details of the app opened prior
+			
+			if (this.player_window == null || this.focused_window != this.player_window){//activate player
+				this.previous_app_window = this.focused_window;
+				app.activate();
+				this.player_window = this.getActiveWindow();
+				return
+			}
+
+			//if player was minimised before activatePlayer, re-minimise it
+			
+			if (this.previous_app_window){//restore previous window
+				this.previous_app_window.activate(global.get_current_time());
+				// AltTab.AppSwitcherPopup.previousWindow(); //does nothing
+			}
 		}
+	}
+	getActiveWindow(){
+		for (const actor of global.get_window_actors()) {
+			const window = actor.get_meta_window();
+			if (window.has_focus())
+				return window;
+		}
+		
+		return null
 	}
 }
 

--- a/players.js
+++ b/players.js
@@ -268,7 +268,8 @@ class Player {
 					this.player_window_minimized = this.player_window.minimized
 				else {
 					let window = this._guessAppWindow(this.identity);
-					this.player_window_minimized = window.minimized;
+					if (window)
+						this.player_window_minimized = window.minimized;
 				}
 
 				app.activate();

--- a/players.js
+++ b/players.js
@@ -1,7 +1,6 @@
 const {Clutter,Gio,GLib,GObject,Shell,St,Meta} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
-const altTab = imports.ui.altTab;
 
 const mprisInterface = `
 <node>

--- a/players.js
+++ b/players.js
@@ -260,25 +260,28 @@ class Player {
 	}
 	activatePlayer(){
 		let focusedWindow = global.display.get_focus_window();
+		let playerWindow = this._guessAppWindow(this.identity);
+		let currentWorkspace = global.workspace_manager.get_active_workspace();
 
-		if (!this.playerWindow)
-			this.playerWindow = this._guessAppWindow(this.identity);
-
-		if (!this.playerWindow)
+		if (!playerWindow)
 			return
 
-		if (focusedWindow == this.playerWindow){
-			if (this.playerWindowMinimized)
-				playerWindow.minimize();
+		if (focusedWindow == playerWindow){
+			if (currentWorkspace == this.previousWorkspace){ //go back to last workspace
+				if (this.playerWindowMinimized)
+					playerWindow.minimize();
 
-			this.previousWindow.activate(global.get_current_time());
+				this.previousWindow.activate(global.get_current_time());
+			}
+			else if (this.previousWorkspace)//focus window on current workspace
+				this.previousWorkspace.activate(global.get_current_time());
 		}
 		else{
 			if(this.desktopApp){
+				this.previousWorkspace = currentWorkspace;
 				this.previousWindow = focusedWindow;
-				this.playerWindowMinimized = this.playerWindow.minimized;
+				this.playerWindowMinimized = playerWindow.minimized;
 				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
-				this.playerWindow = global.display.get_focus_window();
 			}
 		}
 	}

--- a/players.js
+++ b/players.js
@@ -168,6 +168,7 @@ class Player {
 
 		const entryWrapper = Gio.DBusProxy.makeProxyWrapper(entryInterface);
 		this.entryProxy = entryWrapper(Gio.DBus.session,this.address, "/org/mpris/MediaPlayer2",this._onEntryProxyReady.bind(this));
+
 	}
 	_onEntryProxyReady(){
 		this.identity = this.entryProxy.Identity;
@@ -194,8 +195,6 @@ class Player {
 			this.desktopApp = this._matchRunningApps(matchedEntries)
 
 		this.icon = this.getIcon(this.desktopApp);
-
-		this.playerWindow = this._guessAppWindow(this.identity);
 	}
 	_matchRunningApps(matchedEntries){
 		const activeApps = Shell.AppSystem.get_default().get_running();
@@ -263,13 +262,14 @@ class Player {
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
 			let focused_window = global.display.get_focus_window();
+			let player_window = this._guessAppWindow(this.identity);
 
-			if (!this.playerWindow)
+			if (!player_window)
 				return
 
-			if (focused_window == this.playerWindow){
-				if (this.isWindowMinimized)
-					this.playerWindow.minimize();
+			if (focused_window == player_window){
+				if (this.player_window_minimized)
+					player_window.minimize();
 
 				//window to be focused is at the end of the list, just before player and Gnome-shell
 				let windows_list = global.get_window_actors();
@@ -277,7 +277,7 @@ class Player {
 				app_window.activate(global.get_current_time()); //equivalent to Alt+tab
 			}
 			else{
-				this.isWindowMinimized = this.playerWindow.minimized;
+				this.player_window_minimized = player_window.minimized;
 				app.activate();
 			}
 		}

--- a/players.js
+++ b/players.js
@@ -269,11 +269,17 @@ class Player {
 			if (this.playerWindowMinimized)
 				playerWindow.minimize();
 
-			let apps = Shell.AppSystem.get_default().get_running();
-			apps[1].activate(global.get_current_time());
+			let current_workspace = global.workspace_manager.get_active_workspace();
+			if (current_workspace != this.app_workspace) //go back to last workspace
+				this.app_workspace.activate(global.get_current_time());
+			else {//focus window on current workspace
+				let apps = Shell.AppSystem.get_default().get_running();
+				apps[1].activate(global.get_current_time());
+			}
 		}
 		else{
 			if(this.desktopApp){
+				this.app_workspace = global.workspace_manager.get_active_workspace();//save workspace
 				this.playerWindowMinimized = playerWindow.minimized;
 				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
 			}

--- a/players.js
+++ b/players.js
@@ -275,23 +275,24 @@ class Player {
 		else{
 			if(this.desktopApp){
 				this.focusedApp = global.display.get_focus_window(); //save focused window
-				let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
 				this.playerWindowMinimized = playerWindow.minimized;
-				app.activate();
+				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
 			}
 		}
 	}
 	_guessAppWindow(identity){//secondary best-guess method to match player with window
 		identity = identity.toLowerCase();
+		let windows_list = global.get_window_actors();
+		windows_list = windows_list.filter(element => element.get_meta_window().get_window_type() == 0); //only keep normal windows
 		
-		for (const actor of global.get_window_actors()) {//first pass exact match
+		for (const actor of windows_list) {//first pass exact match
 			const window = actor.get_meta_window();
 			let wm_class = window.get_wm_class().toLowerCase();
 			if (wm_class == identity)
 				return window;
 		}
 		
-		for (const actor of global.get_window_actors()) {//fallback approximate match
+		for (const actor of windows_list) {//fallback approximate match
 			const window = actor.get_meta_window();
 			let wm_class = window.get_wm_class().toLowerCase();
 			if (wm_class.includes(identity) | identity.includes(wm_class))

--- a/players.js
+++ b/players.js
@@ -260,12 +260,14 @@ class Player {
 	}
 	activatePlayer(){
 		let focusedWindow = global.display.get_focus_window();
-		let playerWindow = this._guessAppWindow(this.identity);
 
-		if (!playerWindow)
+		if (!this.playerWindow)
+			this.playerWindow = this._guessAppWindow(this.identity);
+
+		if (!this.playerWindow)
 			return
 
-		if (focusedWindow == playerWindow){
+		if (focusedWindow == this.playerWindow){
 			if (this.playerWindowMinimized)
 				playerWindow.minimize();
 
@@ -274,8 +276,9 @@ class Player {
 		else{
 			if(this.desktopApp){
 				this.previousWindow = focusedWindow;
-				this.playerWindowMinimized = playerWindow.minimized;
+				this.playerWindowMinimized = this.playerWindow.minimized;
 				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
+				this.playerWindow = global.display.get_focus_window();
 			}
 		}
 	}

--- a/players.js
+++ b/players.js
@@ -261,25 +261,25 @@ class Player {
 	activatePlayer(){
 		let focusedWindow = global.display.get_focus_window();
 		let playerWindow = this._guessAppWindow(this.identity);
+		let currentWorkspace = global.workspace_manager.get_active_workspace();
 
 		if (!playerWindow)
 			return
 
 		if (focusedWindow == playerWindow){
-			if (this.playerWindowMinimized)
-				playerWindow.minimize();
+			if (currentWorkspace == this.previousWorkspace){ //go back to last workspace
+				if (this.playerWindowMinimized)
+					playerWindow.minimize();
 
-			let current_workspace = global.workspace_manager.get_active_workspace();
-			if (current_workspace != this.app_workspace) //go back to last workspace
-				this.app_workspace.activate(global.get_current_time());
-			else {//focus window on current workspace
-				let apps = Shell.AppSystem.get_default().get_running();
-				apps[1].activate(global.get_current_time());
+				this.previousWindow.activate(global.get_current_time());
 			}
+			else if (this.previousWorkspace)//focus window on current workspace
+				this.previousWorkspace.activate(global.get_current_time());
 		}
 		else{
 			if(this.desktopApp){
-				this.app_workspace = global.workspace_manager.get_active_workspace();//save workspace
+				this.previousWorkspace = currentWorkspace;
+				this.previousWindow = focusedWindow;
 				this.playerWindowMinimized = playerWindow.minimized;
 				Shell.AppSystem.get_default().lookup_app(this.desktopApp).activate();
 			}

--- a/players.js
+++ b/players.js
@@ -262,28 +262,24 @@ class Player {
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
 			let focused_window = global.display.get_focus_window();
+			let player_window = this._guessAppWindow(this.identity);
 
-			if (this.player_window == null || focused_window != this.player_window){//activate player
-				if (this.player_window)//only able to record status once window is known
-					this.player_window_minimized = this.player_window.minimized
-				else {
-					let window = this._guessAppWindow(this.identity);
-					if (window)
-						this.player_window_minimized = window.minimized;
-				}
-
-				app.activate();
-				this.player_window = global.display.get_focus_window();
+			// if search fails: do nothing
+			if (!player_window)
 				return
-			}
 
-			if (this.player_window_minimized)
-				this.player_window.minimize();
+			// if focused_window is player window: minimize
+			if (focused_window == player_window)
+				player_window.minimize();
+
+			// if focused_window isn't player window: focus the player window
+			else
+				app.activate();
 
 			// equivalent to Alt+tab. window to be focused is at the end of the list, just before player and Gnome-shell
-			let windows_list = global.get_window_actors();
-			let app_window = windows_list[windows_list.length - 3].get_meta_window(); 
-			app_window.activate(global.get_current_time());
+			//let windows_list = global.get_window_actors();
+			//let app_window = windows_list[windows_list.length - 3].get_meta_window();
+			//app_window.activate(global.get_current_time());
 		}
 	}
 	_guessAppWindow(identity){//secondary best-guess method to match player with window

--- a/players.js
+++ b/players.js
@@ -264,22 +264,17 @@ class Player {
 			let focused_window = global.display.get_focus_window();
 			let player_window = this._guessAppWindow(this.identity);
 
-			// if search fails: do nothing
 			if (!player_window)
 				return
 
-			// if focused_window is player window: minimize
-			if (focused_window == player_window)
-				player_window.minimize();
-
-			// if focused_window isn't player window: focus the player window
+			if (focused_window == player_window){
+				//window to be focused is at the end of the list, just before player and Gnome-shell
+				let windows_list = global.get_window_actors();
+				let app_window = windows_list[windows_list.length - 3].get_meta_window();
+				app_window.activate(global.get_current_time()); //equivalent to Alt+tab
+			}
 			else
 				app.activate();
-
-			// equivalent to Alt+tab. window to be focused is at the end of the list, just before player and Gnome-shell
-			//let windows_list = global.get_window_actors();
-			//let app_window = windows_list[windows_list.length - 3].get_meta_window();
-			//app_window.activate(global.get_current_time());
 		}
 	}
 	_guessAppWindow(identity){//secondary best-guess method to match player with window

--- a/players.js
+++ b/players.js
@@ -266,6 +266,10 @@ class Player {
 			if (this.player_window == null || focused_window != this.player_window){//activate player
 				if (this.player_window)//only able to record status once window is known
 					this.player_window_minimized = this.player_window.minimized
+				else {
+					let window = this._guessAppWindow(this.identity);
+					this.player_window_minimized = window.minimized;
+				}
 
 				app.activate();
 				this.player_window = global.display.get_focus_window();
@@ -279,6 +283,15 @@ class Player {
 			let windows_list = global.get_window_actors();
 			let app_window = windows_list[windows_list.length - 3].get_meta_window(); 
 			app_window.activate(global.get_current_time());
+		}
+	}
+	_guessAppWindow(identity){//secondary best-guess method to match player with window
+		identity = identity.toLowerCase();
+		for (const actor of global.get_window_actors()) {
+			const window = actor.get_meta_window();
+			let wm_class = window.get_wm_class().toLowerCase();
+			if (wm_class.includes(identity) | identity.includes(wm_class))
+				return window;
 		}
 	}
 }

--- a/players.js
+++ b/players.js
@@ -260,25 +260,23 @@ class Player {
 			this.proxy.PreviousRemote()
 	}
 	activatePlayer(){
-		let focused_window = global.display.get_focus_window();
-		let player_window = this._guessAppWindow(this.identity);
+		let focusedWindow = global.display.get_focus_window();
+		let playerWindow = this._guessAppWindow(this.identity);
 
-		if (!player_window)
+		if (!playerWindow)
 			return
 
-		if (focused_window == player_window){
-			if (this.player_window_minimized)
-				player_window.minimize();
+		if (focusedWindow == playerWindow && this.focusedApp){
+			if (this.playerWindowMinimized)
+				playerWindow.minimize();
 
-			let windows_list = global.get_window_actors();
-			windows_list = windows_list.filter(element => element.get_meta_window().get_window_type() == 0); //filter out non-normal windows
-			let app_window = windows_list[windows_list.length - 2].get_meta_window(); //window to be focused is at the end of the list, just before player
-			app_window.activate(global.get_current_time());
+			this.focusedApp.activate(global.get_current_time());
 		}
 		else{
 			if(this.desktopApp){
+				this.focusedApp = global.display.get_focus_window(); //save focused window
 				let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
-				this.player_window_minimized = player_window.minimized;
+				this.playerWindowMinimized = playerWindow.minimized;
 				app.activate();
 			}
 		}

--- a/players.js
+++ b/players.js
@@ -1,7 +1,7 @@
 const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
-const AltTab = imports.ui.altTab;
+//const AltTab = imports.ui.altTab;
 
 const mprisInterface = `
 <node>
@@ -262,10 +262,10 @@ class Player {
 	activatePlayer(){
 		if(this.desktopApp){
 			let app = Shell.AppSystem.get_default().lookup_app(this.desktopApp);
-			this.focused_window = this.getActiveWindow();//get details of the app opened prior
+			let focused_window = this.getActiveWindow();//get details of the app opened prior
 			
-			if (this.player_window == null || this.focused_window != this.player_window){//activate player
-				this.previous_app_window = this.focused_window;
+			if (this.player_window == null || focused_window != this.player_window){//activate player
+				this.previous_app_window = focused_window;
 				app.activate();
 				this.player_window = this.getActiveWindow();
 				return


### PR DESCRIPTION
with reference to #44, this first pass code will refocus the window which was focused before the player is activated.

I haven't quite worked out how to activate alt+tab. For info, the reference code should be here: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/altTab.js

In the meantime, I am saving the previously focused window and re-activating it if the player is focussed.

One thing I would also like to include is minimising the player if it was minimised before being activated.