### PR TITLE
Allow to increase album size to fill panel height

### DIFF
--- a/players.js
+++ b/players.js
@@ -241,7 +241,8 @@ class Player {
 			this.albumArt = new St.Icon({
 				gicon: Gio.Icon.new_for_string(url),
 				style_class: 'system-status-icon',
-				icon_size: size
+				icon_size: size,
+				style: "padding: 0px;"
 			})
 		else this.albumArt = null;
 


### PR DESCRIPTION
We currently have a BoxLayout which doesn't extend to the full height of the panel + an icon within is which doesn't extend all the way to the border of the Box either so it's padding on padding, making the available space for album covers pretty small:
![Screenshot from 2023-06-12 22-18-29](https://github.com/Moon-0xff/gnome-mpris-label/assets/56710655/5b395f7f-2d0d-44a2-b5cc-035a07903cf0)

I decided to play around a bit with borders and padding to see if there was a way to maximise the icon size to possible fully utilise `Main.panel.height`. Turns out it's possible:
![image](https://github.com/Moon-0xff/gnome-mpris-label/assets/56710655/f88bafaf-bda5-41eb-b37c-545563ad0ccd)

The screenshot above is to show how much extra height is being accessed but it looks better without the button focus and even better when activating panel transparency. 

Not necessarily something to set a default but I think that it would be good to allow the user to set the icon to reach the full height if he/she wishes to do so? for into, the icon above is set at 125%.

It might also be possible to round corners if that's neater (I haven't tried yet).s