### PR TITLE
Hide the label completely

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -27,7 +27,6 @@ class MprisLabel extends PanelMenu.Button {
 	_init(){
 		super._init(0.0,'Mpris Label',false);
 
-		this.hideTimeout = null
 		this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 
 		const EXTENSION_INDEX = this.settings.get_int('extension-index');

--- a/extension.js
+++ b/extension.js
@@ -372,20 +372,19 @@ class MprisLabel extends PanelMenu.Button {
 		this.player.connect('updated', () => {
 			const REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused')
 			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay')
-	
+
 			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
-				this._pauseTimeout = setTimeout(()=>this._setText(this.players, true),
+				this._pauseTimeout = setTimeout( () => this._setText(this.players, true),
 				REMOVE_TEXT_PAUSED_DELAY*1000);
-			} else{ 
+			} else{
 				if (this._pauseTimeout != null)
 					clearTimeout(this._pauseTimeout);
 					this._showLabel();
 			}
-			
+
 			this._setText();
 			this._setIcon();
 		});
-
 
 		this.player.connect('entry-ready', () => {
 			this._getStream();
@@ -475,11 +474,13 @@ class MprisLabel extends PanelMenu.Button {
 	}
 
 	_hideLabel(){
-		if(this.visible) this.hide();
+		if(this.visible)
+			this.hide();
 	}
 
 	_showLabel(){
-		if(!this.visible) this.show()
+		if(!this.visible)
+			this.show()
 	}
 });
 

--- a/extension.js
+++ b/extension.js
@@ -369,14 +369,16 @@ class MprisLabel extends PanelMenu.Button {
 		this._setIcon();
 
 		this.player.connect('updated', () => {
-			const REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused')
-			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay')
+			const REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused');
+			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay');
+			const BUTTON_PLACEHOLDER = this.settings.get_string('button-placeholder');
 
 			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
 				this._pauseTimeout =
 					GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,
 					REMOVE_TEXT_PAUSED_DELAY, () => {
-						this._setText(this.players,true);
+						if (this.player && this.player.playbackStatus === "Paused")
+							this.label.set_text(BUTTON_PLACEHOLDER);
 					});
 
 			} else{
@@ -440,12 +442,12 @@ class MprisLabel extends PanelMenu.Button {
 		}
 	}
 
-	_setText(usePlaceholder = false) {
+	_setText() {
 		try{
 			if(this.player == null || undefined)
 				this._hideLabel();
 			else{
-				const label = buildLabel(this.players, usePlaceholder)
+				const label = buildLabel(this.players)
 				if(label.length == 0) this._hideLabel();
 				else this.label.set_text(label);
 			}

--- a/extension.js
+++ b/extension.js
@@ -373,15 +373,15 @@ class MprisLabel extends PanelMenu.Button {
 			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay');
 			const BUTTON_PLACEHOLDER = this.settings.get_string('button-placeholder');
 
-			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
+			if (REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus == "Paused"){
 				this._pauseTimeout =
 					GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,
 					REMOVE_TEXT_PAUSED_DELAY, () => {
-						if (this.player && this.player.playbackStatus === "Paused")
+						if (this.player && this.player.playbackStatus == "Paused")
 							this.label.set_text(BUTTON_PLACEHOLDER);
 					});
 
-			} else{
+			} else {
 				if (this._pauseTimeout){
 					GLib.Source.remove(this._pauseTimeout);
 					this._pauseTimeout = null;
@@ -448,7 +448,7 @@ class MprisLabel extends PanelMenu.Button {
 				this._hideLabel();
 			else {
 				const label = buildLabel(this.players)
-				if(label.length == 0)
+				if (label.length == 0)
 					this._hideLabel();
 				else
 					this.label.set_text(label);
@@ -483,12 +483,12 @@ class MprisLabel extends PanelMenu.Button {
 	}
 
 	_hideLabel(){
-		if(this.visible)
+		if (this.visible)
 			this.hide();
 	}
 
 	_showLabel(){
-		if(!this.visible)
+		if (!this.visible)
 			this.show()
 	}
 });

--- a/extension.js
+++ b/extension.js
@@ -374,7 +374,8 @@ class MprisLabel extends PanelMenu.Button {
 			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay')
 	
 			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
-				this.pauseTimeout = setTimeout(this._hideLabel.bind(this), REMOVE_TEXT_PAUSED_DELAY*1000);
+				this.pauseTimeout = setTimeout(()=>this._setText(this.players, true),
+				REMOVE_TEXT_PAUSED_DELAY*1000);
 			} else{ 
 				if (this.pauseTimeout != null)
 					clearTimeout(this.pauseTimeout);
@@ -435,12 +436,12 @@ class MprisLabel extends PanelMenu.Button {
 		}
 	}
 
-	_setText() {
+	_setText(usePlaceholder = false) {
 		try{
 			if(this.player == null || undefined)
 				this._hideLabel();
 			else{
-				const label = buildLabel(this.players)
+				const label = buildLabel(this.players, usePlaceholder)
 				if(label.length == 0) this._hideLabel();
 				else this.label.set_text(label);
 			}

--- a/extension.js
+++ b/extension.js
@@ -373,8 +373,12 @@ class MprisLabel extends PanelMenu.Button {
 			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay')
 
 			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
-				this._pauseTimeout = setTimeout( () => this._setText(this.players, true),
-				REMOVE_TEXT_PAUSED_DELAY*1000);
+				this._pauseTimeout =
+					GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,
+					REMOVE_TEXT_PAUSED_DELAY, () => {
+						this._setText(this.players,true);
+					});
+
 			} else{
 				if (this._pauseTimeout != null)
 					clearTimeout(this._pauseTimeout);

--- a/extension.js
+++ b/extension.js
@@ -380,8 +380,10 @@ class MprisLabel extends PanelMenu.Button {
 					});
 
 			} else{
-				if (this._pauseTimeout != null)
-					clearTimeout(this._pauseTimeout);
+				if (this._pauseTimeout){
+					GLib.Source.remove(this._pauseTimeout);
+					this._pauseTimeout = null;
+				}
 					this._showLabel();
 			}
 

--- a/extension.js
+++ b/extension.js
@@ -374,11 +374,11 @@ class MprisLabel extends PanelMenu.Button {
 			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay')
 	
 			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
-				this.pauseTimeout = setTimeout(()=>this._setText(this.players, true),
+				this._pauseTimeout = setTimeout(()=>this._setText(this.players, true),
 				REMOVE_TEXT_PAUSED_DELAY*1000);
 			} else{ 
-				if (this.pauseTimeout != null)
-					clearTimeout(this.pauseTimeout);
+				if (this._pauseTimeout != null)
+					clearTimeout(this._pauseTimeout);
 					this._showLabel();
 			}
 			
@@ -466,6 +466,11 @@ class MprisLabel extends PanelMenu.Button {
 		if (this._repositionTimeout){
 			GLib.Source.remove(this._repositionTimeout);
 			this._repositionTimeout = null;
+		}
+
+		if (this._pauseTimeout){
+			GLib.Source.remove(this._pauseTimeout);
+			this._pauseTimeout = null;
 		}
 	}
 

--- a/extension.js
+++ b/extension.js
@@ -73,6 +73,8 @@ class MprisLabel extends PanelMenu.Button {
 
 		Main.panel.addToStatusArea('Mpris Label',this,EXTENSION_INDEX,EXTENSION_PLACE);
 
+		this._hideLabel()
+
 		this._repositionTimeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,REPOSITION_DELAY,this._updateTrayPosition.bind(this));
 	}
 
@@ -361,7 +363,7 @@ class MprisLabel extends PanelMenu.Button {
 	}
 
 	_onSelectedChanged(){
-	this.player = this.players.selected;
+		this.player = this.players.selected;
 
 		this._getStream();
 		this._setText();
@@ -372,10 +374,11 @@ class MprisLabel extends PanelMenu.Button {
 			const REMOVE_TEXT_PAUSED_DELAY = this.settings.get_int('remove-text-paused-delay')
 	
 			if(REMOVE_TEXT_WHEN_PAUSED && this.player.playbackStatus==="Paused"){
-				this.pauseTimeout = setTimeout(this._hideLabel.bind(this), REMOVE_TEXT_PAUSED_DELAY*1000)
-			} else if (this.pauseTimeout != null){
-				clearTimeout(this.pauseTimeout)
-				this._showLabel()
+				this.pauseTimeout = setTimeout(this._hideLabel.bind(this), REMOVE_TEXT_PAUSED_DELAY*1000);
+			} else{ 
+				if (this.pauseTimeout != null)
+					clearTimeout(this.pauseTimeout);
+					this._showLabel();
 			}
 			
 			this._setText();
@@ -435,13 +438,16 @@ class MprisLabel extends PanelMenu.Button {
 	_setText() {
 		try{
 			if(this.player == null || undefined)
-				this.label.set_text("");
-			else
-				this.label.set_text(buildLabel(this.players));
+				this._hideLabel();
+			else{
+				const label = buildLabel(this.players)
+				if(label.length == 0) this._hideLabel();
+				else this.label.set_text(label);
+			}
 		}
 		catch(err){
 			log("Mpris Label: " + err);
-			this.label.set_text("");
+			this._hideLabel();
 		}
 	}
 

--- a/extension.js
+++ b/extension.js
@@ -446,10 +446,12 @@ class MprisLabel extends PanelMenu.Button {
 		try{
 			if(this.player == null || undefined)
 				this._hideLabel();
-			else{
+			else {
 				const label = buildLabel(this.players)
-				if(label.length == 0) this._hideLabel();
-				else this.label.set_text(label);
+				if(label.length == 0)
+					this._hideLabel();
+				else
+					this.label.set_text(label);
 			}
 		}
 		catch(err){

--- a/label.js
+++ b/label.js
@@ -16,17 +16,19 @@ function getSettings(){
 	LAST_FIELD = settings.get_string('last-field');
 }
 
-var buildLabel = function buildLabel(players, usePlaceholder = false){
+var buildLabel = function buildLabel(players){
 	getSettings();
+
 	// the placeholder string is a hint for the user to switch players
 	// it should appear if labelstring is empty and there's another player playing
 	// avoid returning empty strings directly, use "placeholder" instead
 	let placeholder = "";
-	if (players.activePlayers.length > 0 && players.selected.playbackStatus != "Playing" || usePlaceholder)
+	if (players.activePlayers.length > 0 && players.selected.playbackStatus != "Playing")
 		placeholder = BUTTON_PLACEHOLDER;
+
 	let metadata = players.selected.metadata;
 
-	if(metadata == null || usePlaceholder)
+	if(metadata == null)
 		return placeholder
 
 	let fields = [FIRST_FIELD,SECOND_FIELD,LAST_FIELD]; //order is user-defined

--- a/label.js
+++ b/label.js
@@ -2,8 +2,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
 
 let MAX_STRING_LENGTH,BUTTON_PLACEHOLDER,LABEL_FILTERED_LIST,
-	DIVIDER_STRING,REMOVE_TEXT_WHEN_PAUSED,
-	REMOVE_TEXT_PAUSED_DELAY,FIRST_FIELD,SECOND_FIELD,LAST_FIELD
+	DIVIDER_STRING,FIRST_FIELD,SECOND_FIELD,LAST_FIELD
 	MAX_STRING_LENGTH,DIVIDER_STRING;
 
 function getSettings(){
@@ -12,8 +11,6 @@ function getSettings(){
 	BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
 	LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
 	DIVIDER_STRING = settings.get_string('divider-string');
-	REMOVE_TEXT_WHEN_PAUSED = settings.get_boolean('remove-text-when-paused');
-	REMOVE_TEXT_PAUSED_DELAY = settings.get_int('remove-text-paused-delay');
 	FIRST_FIELD = settings.get_string('first-field');
 	SECOND_FIELD = settings.get_string('second-field');
 	LAST_FIELD = settings.get_string('last-field');
@@ -28,14 +25,6 @@ var buildLabel = function buildLabel(players){
 	let placeholder = "";
 	if (players.activePlayers.length > 0 && players.selected.playbackStatus != "Playing")
 		placeholder = BUTTON_PLACEHOLDER;
-
-	if(REMOVE_TEXT_WHEN_PAUSED && players.selected.playbackStatus != "Playing"){
-		const statusTimestamp = players.selected.statusTimestamp / 1000;
-		const currentTimestamp = new Date().getTime() / 1000;
-
-		if(statusTimestamp + REMOVE_TEXT_PAUSED_DELAY <= currentTimestamp)
-			return placeholder
-	}
 
 	let metadata = players.selected.metadata;
 

--- a/label.js
+++ b/label.js
@@ -16,19 +16,17 @@ function getSettings(){
 	LAST_FIELD = settings.get_string('last-field');
 }
 
-var buildLabel = function buildLabel(players){
+var buildLabel = function buildLabel(players, usePlaceholder = false){
 	getSettings();
-
 	// the placeholder string is a hint for the user to switch players
 	// it should appear if labelstring is empty and there's another player playing
 	// avoid returning empty strings directly, use "placeholder" instead
 	let placeholder = "";
-	if (players.activePlayers.length > 0 && players.selected.playbackStatus != "Playing")
+	if (players.activePlayers.length > 0 && players.selected.playbackStatus != "Playing" || usePlaceholder)
 		placeholder = BUTTON_PLACEHOLDER;
-
 	let metadata = players.selected.metadata;
 
-	if(metadata == null)
+	if(metadata == null || usePlaceholder)
 		return placeholder
 
 	let fields = [FIRST_FIELD,SECOND_FIELD,LAST_FIELD]; //order is user-defined


### PR DESCRIPTION
This implements the changes requested in order to hide the label when changed, mentioned in https://github.com/Moon-0xff/gnome-mpris-label/pull/68.

This branch can also be used to implement the auto switch option...

The difference between this is and the previous solution is that it uses the new optimised event system.