### PR TITLE
add reset buttons in Preferences

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -198,6 +198,12 @@ function addDropDown(group,setting,labelstring,options,labeltooltip){
 		thisResetButton.set_visible(true);
 	});
 
+	//label for debugging
+	let thisLabel = new Gtk.Label({
+		label: 'default: '+thisComboRow._defaultValueIndex.toString()
+	})
+	row.add_suffix(thisLabel);
+
 	row.add_suffix(thisResetButton);
 	row.add_suffix(thisComboRow);
 

--- a/prefs.js
+++ b/prefs.js
@@ -19,14 +19,14 @@ function fillPreferencesWindow(window){
 	page = addPreferencesPage(window,'Panel','computer-symbolic');
 
 	group = addGroup(page,'Icon');
-	let showIconComboBox = addStringComboRow(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
+	let showIconComboBox = addDropDown(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
 	addSpinButton(group, 'icon-padding', 'Icon padding', 0, 50, undefined);
 	addSwitch(group, 'symbolic-source-icon', 'Use symbolic source icon', "Uses an icon that follows the shell's color scheme");
 	addSwitch(group,'use-album','Use album art as icon when available',undefined);
 	addSpinButton(group,'album-size','Album art scaling (in %)',20,250,undefined);
 
 	group = addGroup(page,'Position');
-	let extensionPlaceComboBox = addStringComboRow(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
+	let extensionPlaceComboBox = addDropDown(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
 	addSpinButton(group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
 	addSpinButton(group,'left-padding','Left padding',0,500,undefined);
 	addSpinButton(group,'right-padding','Right padding',0,500,undefined);
@@ -68,7 +68,7 @@ function fillPreferencesWindow(window){
 	let fieldOptions1 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title'};
 	let fieldOptions2 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
 	let fieldOptions3 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
-	let [firstFieldComboBox, secondFieldComboBox, lastFieldComboBox] = addTripleStringComboBox(group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
+	let [firstFieldComboBox, secondFieldComboBox, lastFieldComboBox] = addTripleStringDropDown(group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
 
 	//Reset Button
 	addButton(group,'Reset Label settings', () => {
@@ -147,18 +147,18 @@ function fillPreferencesWindow(window){
 	row.add_suffix(doubleClickLabel);
 	group.add(row);
 
-	let [leftClickComboBox, leftDoubleClickComboBox] = addDoubleStringComboBox(group,'left-click-action','left-double-click-action','Left click',buttonActions,undefined);
-	let [middleClickComboBox, middleDoubleClickComboBox] = addDoubleStringComboBox(group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,undefined,);
-	let [rightClickComboBox, rightDoubleClickComboBox] = addDoubleStringComboBox(group,'right-click-action','right-double-click-action','Right click',buttonActions,undefined);
-	let [thumbForwardComboBox, thumbDoubleForwardComboBox] = addDoubleStringComboBox(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,undefined);
-	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringComboBox(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
+	let [leftClickComboBox, leftDoubleClickComboBox] = addDoubleStringDropDown(group,'left-click-action','left-double-click-action','Left click',buttonActions,undefined);
+	let [middleClickComboBox, middleDoubleClickComboBox] = addDoubleStringDropDown(group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,undefined,);
+	let [rightClickComboBox, rightDoubleClickComboBox] = addDoubleStringDropDown(group,'right-click-action','right-double-click-action','Right click',buttonActions,undefined);
+	let [thumbForwardComboBox, thumbDoubleForwardComboBox] = addDoubleStringDropDown(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,undefined);
+	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringDropDown(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
 
 	group = addGroup(page,'');
-	let scrollComboBox = addStringComboRow(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
+	let scrollComboBox = addDropDown(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
 	scrollComboBox.set_size_request(140,-1); //match size with next button
 
 	group = addGroup(page,'Behaviour');
-	let VolumeControlComboBox = addStringComboRow(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
+	let VolumeControlComboBox = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
 	VolumeControlComboBox.set_size_request(140,-1); //match size with previous button
 
 	//Reset Button
@@ -339,7 +339,7 @@ function buildDropDownResetButton(setting,combobox,options){
 	return thisResetButton;
 }
 
-function addStringComboRow(group,setting,labelstring,options,labeltooltip){
+function addDropDown(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 135;
 
@@ -360,7 +360,7 @@ function addStringComboRow(group,setting,labelstring,options,labeltooltip){
 	return thisComboRow;
 }
 
-function addDoubleStringComboBox(group, setting1, setting2, labelstring, options, labeltooltip){
+function addDoubleStringDropDown(group, setting1, setting2, labelstring, options, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 135;
 
@@ -387,7 +387,7 @@ function addDoubleStringComboBox(group, setting1, setting2, labelstring, options
 	return [comboBox1, comboBox2]
 }
 
-function addTripleStringComboBox(group, setting1, setting2, setting3, labelstring, options1, options2, options3, labeltooltip){
+function addTripleStringDropDown(group, setting1, setting2, setting3, labelstring, options1, options2, options3, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 85;
 
@@ -487,7 +487,7 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 	return thisEntry;
 }
 
-function buildStringComboBox(settings,setting,options,width){
+function buildStringDropDown(settings,setting,options,width){
 	let thisComboBox = new Gtk.ComboBoxText({//consider using Adw.ComboRow
 		valign: Gtk.Align.CENTER,
 		halign: Gtk.Align.END,

--- a/prefs.js
+++ b/prefs.js
@@ -285,7 +285,7 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 	thisSwitch.connect('state-set',() => {
 		if (settings.get_boolean(setting) == Boolean(settings.get_default_value(setting)))
 			resetButton.set_visible(false);
-		else 
+		else
 			resetButton.set_visible(true)
 	})
 
@@ -313,7 +313,7 @@ function addEntry(group,setting,labelstring,labeltooltip){
 }
 
 function addWideEntry(group,setting,placeholder,labeltooltip){
-	let thisEntry = new Gtk.Entry({ 
+	let thisEntry = new Gtk.Entry({
 		visible: true,
 		secondary_icon_name: '',
 		secondary_icon_tooltip_text: "Reset to Default"
@@ -330,7 +330,7 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 
 		thisEntry.connect('changed',() => {
 			if (settings.get_string(setting)) //default for WideEntry is to be empty
-				thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');	
+				thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');
 			else
 				thisEntry.set_icon_from_icon_name(1,'');
 		})

--- a/prefs.js
+++ b/prefs.js
@@ -201,8 +201,10 @@ function addDropDown(group,setting,labelstring,options,labeltooltip){
 	let thisResetButton = buildDropDownResetButton([setting],[thisComboRow],[options])
 
 	thisComboRow.connect('notify::selected-item', () => {
-		settings.set_string(setting,Object.values(options)[thisComboRow.get_selected()]);
-		thisResetButton.set_visible(true);
+		let dropDownValue = Object.values(options)[thisComboRow.get_selected()]
+		settings.set_string(setting,dropDownValue);
+		let setVisible = setComboResetVisibility([setting],[thisComboRow],[options]);
+		thisResetButton.set_visible(setVisible)
 	});
 
 	row.add_suffix(thisResetButton);
@@ -222,13 +224,22 @@ function addDoubleStringDropDown(group, setting1, setting2, labelstring, options
 	let thisResetButton = buildDropDownResetButton([setting1,setting2],[comboBox1,comboBox2],[options,options])
 
 	comboBox1.connect('notify::selected-item', () => {
-		settings.set_string(setting1,Object.values(options)[comboBox1.get_selected()]);
-		thisResetButton.set_visible(true);
+		let dropDownValue = Object.values(options)[comboBox1.get_selected()];
+		settings.set_string(setting1,dropDownValue);
+		let setVisible = setComboResetVisibility([setting1,setting2],[comboBox1,comboBox2],[options,options]);
+		thisResetButton.set_visible(setVisible)
 	});
 
 	comboBox2.connect('notify::selected-item', () => {
-		settings.set_string(setting2,Object.values(options)[comboBox2.get_selected()]);
-		thisResetButton.set_visible(true);
+		let dropDownValue = Object.values(options)[comboBox2.get_selected()];
+		settings.set_string(setting2,dropDownValue);
+		let setVisible = setComboResetVisibility([setting1,setting2],[comboBox1,comboBox2],[options,options]);
+		thisResetButton.set_visible(setVisible)
+		// //hide reset button if both values match default
+		// if (dropDownValue1 == settings.get_default_value(setting1).print(true).replaceAll('\'', '') && dropDownValue2 == settings.get_default_value(setting2).print(true).replaceAll('\'', ''))
+		// 	thisResetButton.set_visible(false);
+		// else
+		// 	thisResetButton.set_visible(true);
 	});
 
 	row.add_suffix(thisResetButton);
@@ -251,17 +262,20 @@ function addTripleStringDropDown(group, setting1, setting2, setting3, labelstrin
 
 	comboBox1.connect('notify::selected-item', () => {
 		settings.set_string(setting1,Object.values(options1)[comboBox1.get_selected()]);
-		thisResetButton.set_visible(true);
+		let setVisible = setComboResetVisibility([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3]);
+		thisResetButton.set_visible(setVisible)
 	});
 
 	comboBox2.connect('notify::selected-item', () => {
 		settings.set_string(setting2,Object.values(options2)[comboBox2.get_selected()]);
-		thisResetButton.set_visible(true);
+		let setVisible = setComboResetVisibility([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3]);
+		thisResetButton.set_visible(setVisible)
 	});
 
 	comboBox3.connect('notify::selected-item', () => {
 		settings.set_string(setting3,Object.values(options3)[comboBox3.get_selected()]);
-		thisResetButton.set_visible(true);
+		let setVisible = setComboResetVisibility([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3]);
+		thisResetButton.set_visible(setVisible)
 	});
 
 	row.add_suffix(thisResetButton);
@@ -271,6 +285,16 @@ function addTripleStringDropDown(group, setting1, setting2, setting3, labelstrin
 
 	group.add(row)
 	return [comboBox1, comboBox2, comboBox3]
+}
+
+function setComboResetVisibility(settingsList,dropDownList,optionsList){ //show reset button if any of the values is different from default
+	let setVisible = false;
+	for (let i = 0; i < dropDownList.length; i++) {
+		let dropDownValue = Object.values(optionsList[i])[dropDownList[i].get_selected()];
+		if (dropDownValue != settings.get_default_value(settingsList[i]).print(true).replaceAll('\'', ''))
+			setVisible = true;
+	}
+	return setVisible;
 }
 
 function addSwitch(group,setting,labelstring,labeltooltip){
@@ -461,7 +485,7 @@ function buildDropDownResetButton(setting,combobox,options){
 
 	//hide if default setting
 	setting.forEach((item) => {
-		if (settings.get_user_value(item) != null && settings.get_user_value(item) != settings.get_default_value(item))
+		if (settings.get_value(item).print(true) != settings.get_default_value(item).print(true))
 			thisResetButton.set_visible(true);
 	})
 

--- a/prefs.js
+++ b/prefs.js
@@ -154,11 +154,11 @@ function fillPreferencesWindow(window){
 	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringComboBox(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
 
 	group = addGroup(page,'');
-	let scrollComboBox = addStringComboBox(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
+	let scrollComboBox = addStringComboRow(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
 	scrollComboBox.set_size_request(140,-1); //match size with next button
 
 	group = addGroup(page,'Behaviour');
-	let VolumeControlComboBox = addStringComboBox(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
+	let VolumeControlComboBox = addStringComboRow(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
 	VolumeControlComboBox.set_size_request(140,-1); //match size with previous button
 
 	//Reset Button
@@ -301,24 +301,57 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	return thisSpinButton;
 }
 
+function buildStringComboRow(settings,setting,options,width){
+
+	let thisDropDown = new Gtk.DropDown({
+		model: Gtk.StringList.new(Object.keys(options)),
+		selected: Object.values(options).indexOf(settings.get_string(setting)),
+		valign: Gtk.Align.CENTER,
+		halign: Gtk.Align.END
+	});
+
+	if (width)
+		thisDropDown.set_size_request(105,-1);
+
+	// thisDropDown.connect('notify::selected-item', () => {
+	// 	settings.set_string(setting,'right');
+	// });
+
+	return thisDropDown;
+}
+
 function addStringComboRow(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let thisComboRow = new Adw.ComboRow({
-		model: Gtk.StringList.new(Object.keys(options)),
-		selected: Object.keys(options).indexOf(settings.get_string(setting)),
-		valign: Gtk.Align.END
+	let thisComboRow = buildStringComboRow(settings,setting,options,105)
+
+	let thisResetButton = new Gtk.Button({
+		valign: Gtk.Align.CENTER,
+		icon_name: 'edit-clear-symbolic-rtl',
+		visible: false
 	});
 
-	let resetButton = buildResetButton(setting);
+	//hide if default setting
+	if (settings.get_string(setting))
+		thisResetButton.set_visible(true);
 
-	row.add_suffix(resetButton);
-	row.add_suffix(thisComboRow);
+	thisResetButton.add_css_class('flat');
+	thisResetButton.set_tooltip_text('Reset to Default');
 
 	thisComboRow.connect('notify::selected-item', () => {
-		settings.set_string(setting,Object.values(options)[thisComboRow.get_selected().id]);
-		resetButton.set_visible(true);
+		settings.set_string(setting,'right');
+		settings.set_string(setting,Object.values(options)[thisComboRow.get_selected()]);
+		thisResetButton.set_visible(true);
 	});
+
+	thisResetButton.connect('clicked',() => {
+		settings.reset(setting);
+		thisComboRow.set_selected(Object.values(options).indexOf(settings.get_string(setting)));
+		thisResetButton.set_visible(false);
+	});
+
+	row.add_suffix(thisResetButton);
+	row.add_suffix(thisComboRow);
 
 	group.add(row);
 

--- a/prefs.js
+++ b/prefs.js
@@ -282,16 +282,6 @@ function addTripleStringDropDown(group, setting1, setting2, setting3, labelstrin
 	return [thisDropDown1, thisDropDown2, thisDropDown3]
 }
 
-function setDropDownResetVisibility(settingsList,thisDropDownList,optionsList){ //show reset button if any of the values is different from default
-	let setVisible = false;
-	for (let i = 0; i < thisDropDownList.length; i++) {
-		let thisDropDownValue = Object.values(optionsList[i])[thisDropDownList[i].get_selected()];
-		if (thisDropDownValue != settings.get_default_value(settingsList[i]).print(true).replaceAll('\'', ''))
-			setVisible = true;
-	}
-	return setVisible;
-}
-
 function addSwitch(group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
@@ -504,6 +494,16 @@ function buildButton(labelstring,callback){
 }
 
 // helper functions
+
+function setDropDownResetVisibility(settingsList,thisDropDownList,optionsList){ //show reset button if any of the values is different from default
+	let setVisible = false;
+	for (let i = 0; i < thisDropDownList.length; i++) {
+		let thisDropDownValue = Object.values(optionsList[i])[thisDropDownList[i].get_selected()];
+		if (thisDropDownValue != settings.get_default_value(settingsList[i]).print(true).replaceAll('\'', ''))
+			setVisible = true;
+	}
+	return setVisible;
+}
 
 function bindEnabled(settings, setting, element) {
 	settings.bind(setting, element, 'sensitive', Gio.SettingsBindFlags.GET);

--- a/prefs.js
+++ b/prefs.js
@@ -57,7 +57,7 @@ function fillPreferencesWindow(window){
 
 	addResetButton(group,'Reset Label settings',[
 		'max-string-length','refresh-rate','button-placeholder','label-filtered-list','divider-string','first-field','second-field',
-		'last-field','remove-text-when-paused','remove-text-paused-delay','auto-switch-to-most-recent']
+		'last-field','remove-text-when-paused','remove-text-paused-delay','auto-switch-to-most-recent'],[firstFieldDropDown, secondFieldDropDown, lastFieldDropDown]
 	);
 
 //filters page:
@@ -132,7 +132,9 @@ function fillPreferencesWindow(window){
 	addResetButton(group,'Reset Controls settings',[
 		'enable-double-clicks','double-click-time','left-click-action','left-double-click-action','middle-click-action','middle-double-click-action',
 		'right-click-action','right-double-click-action','scroll-action','thumb-forward-action','thumb-double-forward-action','thumb-backward-action',
-		'thumb-double-backward-action','volume-control-scheme']
+		'thumb-double-backward-action','volume-control-scheme'],[leftClickDropDown, leftDoubleClickDropDown,middleClickDropDown, middleDoubleClickDropDown,
+		rightClickDropDown, rightDoubleClickDropDown,thumbForwardDropDown, thumbDoubleForwardDropDown,thumbBackwardDropDown, thumbDoubleBackwardDropDown,
+		scrollDropDown,VolumeControlDropDown]
 	);
 
 	[doubleClickTime, doubleClickLabel, leftDoubleClickDropDown, middleDoubleClickDropDown, rightDoubleClickDropDown, thumbDoubleForwardDropDown, thumbDoubleBackwardDropDown]
@@ -197,12 +199,6 @@ function addDropDown(group,setting,labelstring,options,labeltooltip){
 		settings.set_string(setting,Object.values(options)[thisComboRow.get_selected()]);
 		thisResetButton.set_visible(true);
 	});
-
-	//label for debugging
-	let thisLabel = new Gtk.Label({
-		label: 'default: '+thisComboRow._defaultValueIndex.toString()
-	})
-	row.add_suffix(thisLabel);
 
 	row.add_suffix(thisResetButton);
 	row.add_suffix(thisComboRow);
@@ -349,13 +345,14 @@ function addResetButton(group,labelstring,options,dropDowns){
 		options.forEach(option => {
 			settings.reset(option);
 		});
+		thisButton.set_tooltip_text('clicked');
+		if (dropDowns){
+			thisButton.set_tooltip_text('there are dropdowns');
+			dropDowns.forEach(dropDown => {
+				dropDown.set_selected(dropDown._defaultValueIndex);
+			});
+		}
 	});
-
-	if (dropDowns){
-		dropDowns.forEach(dropDown => {
-			dropDown.set_selected(dropDown._defaultValueIndex);
-		});
-	}
 
 	group.add(thisButton);
 

--- a/prefs.js
+++ b/prefs.js
@@ -481,7 +481,7 @@ function buildButton(labelstring,callback){
 // helper functions
 
 function bindEnabled(settings, setting, element) {
-	settings.bind(setting, element, 'visible', Gio.SettingsBindFlags.GET);
+	settings.bind(setting, element, 'sensitive', Gio.SettingsBindFlags.GET);
 }
 
 // specific job/usage functions

--- a/prefs.js
+++ b/prefs.js
@@ -345,9 +345,7 @@ function addResetButton(group,labelstring,options,dropDowns){
 		options.forEach(option => {
 			settings.reset(option);
 		});
-		thisButton.set_tooltip_text('clicked');
 		if (dropDowns){
-			thisButton.set_tooltip_text('there are dropdowns');
 			dropDowns.forEach(dropDown => {
 				dropDown.set_selected(dropDown._defaultValueIndex);
 			});

--- a/prefs.js
+++ b/prefs.js
@@ -341,7 +341,7 @@ function buildDropDownResetButton(setting,combobox,options){
 
 function addDropDown(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
-	let width = 135;
+	let width = 105;
 
 	let thisComboRow = buildDropDown(settings,setting,options,width)
 
@@ -389,7 +389,7 @@ function addDoubleStringDropDown(group, setting1, setting2, labelstring, options
 
 function addTripleStringDropDown(group, setting1, setting2, setting3, labelstring, options1, options2, options3, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
-	let width = 85;
+	let width = 81;
 
 	let comboBox1 = buildDropDown(settings, setting1, options1,width);
 	let comboBox2 = buildDropDown(settings, setting2, options2,width);
@@ -448,7 +448,7 @@ function addEntry(group,setting,labelstring,labeltooltip){
 	let thisEntry = new Gtk.Entry({
 		valign: Gtk.Align.CENTER,
 		halign: Gtk.Align.END,
-		width_request: 215,
+		width_request: 200,
 		visible: true
 	});
 	settings.bind(setting,thisEntry,'text',Gio.SettingsBindFlags.DEFAULT);

--- a/prefs.js
+++ b/prefs.js
@@ -18,24 +18,20 @@ function fillPreferencesWindow(window){
 //panel page:
 	page = addPreferencesPage(window,'Panel','computer-symbolic');
 
-	group = new Adw.PreferencesGroup({ title: 'Icon'});
-	page.add(group);
-
+	group = addGroup(page,'Icon');
 	let showIconComboBox = addStringComboBox(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
 	addSpinButton(group, 'icon-padding', 'Icon padding', 0, 50, undefined);
 	addSwitch(group, 'symbolic-source-icon', 'Use symbolic source icon', "Uses an icon that follows the shell's color scheme");
 	addSwitch(group,'use-album','Use album art as icon when available',undefined);
 	addSpinButton(group,'album-size','Album art scaling (in %)',20,250,undefined);
 
-	group = new Adw.PreferencesGroup({ title: 'Position'});
-	page.add(group);
+	group = addGroup(page,'Position');
 	let extensionPlaceComboBox = addStringComboBox(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
 	addSpinButton(group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
 	addSpinButton(group,'left-padding','Left padding',0,500,undefined);
 	addSpinButton(group,'right-padding','Right padding',0,500,undefined);
 
-	group = new Adw.PreferencesGroup({ title: 'Wrong index at loadup mitigations'});
-	page.add(group);
+	group = addGroup(page,'Wrong index at loadup mitigations');
 	addSpinButton(group,'reposition-delay','Panel reposition at startup (delay in seconds)',0,300,"Increase this value if extension index isn't respected at startup");
 	addSwitch(group,'reposition-on-button-press','Update panel position on every button press',undefined);
 
@@ -59,16 +55,14 @@ function fillPreferencesWindow(window){
 //label page:
 	page = addPreferencesPage(window,'Label','document-edit-symbolic');
 
-	group = new Adw.PreferencesGroup({ title: 'Behaviour'});
-	page.add(group);
+	group = addGroup(page,'Behaviour');
 	addSwitch(group,'auto-switch-to-most-recent','Switch to the most recent source automatically',"This option can be annoying without the use of filter lists");
 	addSwitch(group,'remove-text-when-paused','Hide when paused',undefined);
 	addSpinButton(group,'remove-text-paused-delay','Hide when paused delay (seconds)',0,9999,undefined);
 	addSpinButton(group,'refresh-rate','Refresh rate (milliseconds)',30,3000,undefined);
 	addEntry(group,'label-filtered-list','Filter segments containing',"Separate entries with commas, special characters will be removed\n\nThe targeted segments are defined in code as:\n\t\A substring enclosed by parentheses, square brackets,\n\t or between the end of the string and a hyphen");
 
-	group = new Adw.PreferencesGroup({ title: 'Appearance'});
-	page.add(group);
+	group = addGroup(page,'Appearance');
 	addSpinButton(group,'max-string-length','Max string length (each field)',1,150,undefined);
 	addEntry(group,'button-placeholder','Button placeholder',"The button placeholder is a hint for the user and can be left empty.\n\nIt appears when the label is empty and another available source is active");
 	addEntry(group,'divider-string','Divider string (you can use spaces)',undefined);
@@ -99,9 +93,7 @@ function fillPreferencesWindow(window){
 //filters page:
 	page = addPreferencesPage(window,'Filters','dialog-error-symbolic');
 
-	group = new Adw.PreferencesGroup({ title: 'List of available MPRIS Sources'});
-	page.add(group);
-
+	group = addGroup(page,'List of available MPRIS Sources');
 	let sourcesListEntry = addWideEntry(group,undefined,'',"Press the button below to update");
 	sourcesListEntry.set_text(playersToString());
 	sourcesListEntry.set_editable(false);
@@ -111,18 +103,15 @@ function fillPreferencesWindow(window){
 	});
 	updateButton.set_margin_top(10);
 
-	group = new Adw.PreferencesGroup({ title: 'Ignore list'});
-	page.add(group);
+	group = addGroup(page,'Ignore list');
 	addWideEntry(group,'mpris-sources-blacklist','Separate entries with commas',undefined);
 
-	group = new Adw.PreferencesGroup({ title: 'Allow list'});
-	page.add(group);
+	group = addGroup(page,'Allow list');
 	addSwitch(group,'use-whitelisted-sources-only','Ignore all sources except allowed ones',"This option is ignored if the allow list is empty");
 	let allowListEntry = addWideEntry(group,'mpris-sources-whitelist','Separate entries with commas',undefined);
 	allowListEntry.set_margin_top(10);
 
-	group = new Adw.PreferencesGroup({ title: 'Players excluded from using album art as icon'});
-	page.add(group);
+	group = addGroup(page,'Players excluded from using album art as icon');
 	addWideEntry(group,'album-blacklist','Separate entries with commas',undefined);
 
 	//Reset Button
@@ -141,14 +130,11 @@ function fillPreferencesWindow(window){
 		'open app':'activate-player','volume mute':'volume-mute','volume up':'volume-up','volume down':'volume-down','none':'none'
 	};
 
-	group = new Adw.PreferencesGroup({ title: 'Double Click'});
-	page.add(group);
-
+	group = addGroup(page,'Double Click');
 	addSwitch(group, 'enable-double-clicks', 'Enable double clicks', undefined);
 	let doubleClickTime = addSpinButton(group, 'double-click-time', 'Double click time (milliseconds)', 1, 1000, undefined);
 
-	group = new Adw.PreferencesGroup({ title: 'Mouse bindings'});
-	page.add(group);
+	group = addGroup(page,'Mouse bindings');
 
 	row = new Adw.ActionRow({ title: ''});
 	let singleClickLabel = new Gtk.Label({ //not sure how to underline or reduce height
@@ -169,13 +155,11 @@ function fillPreferencesWindow(window){
 	let [thumbForwardComboBox, thumbDoubleForwardComboBox] = addDoubleStringComboBox(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,undefined);
 	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringComboBox(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
 
-	group = new Adw.PreferencesGroup({ title: ''});
-	page.add(group);
+	group = addGroup(page,'');
 	let scrollComboBox = addStringComboBox(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
 	scrollComboBox.set_size_request(140,-1); //match size with next button
 
-	group = new Adw.PreferencesGroup({ title: 'Behaviour'});
-	page.add(group);
+	group = addGroup(page,'Behaviour');
 	let VolumeControlComboBox = addStringComboBox(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
 	VolumeControlComboBox.set_size_request(140,-1); //match size with previous button
 
@@ -223,7 +207,13 @@ function addPreferencesPage(window,name,icon){
 		icon_name: icon,
 	});
 	window.add(thisPage);
-	return thisPage
+	return thisPage;
+}
+
+function addGroup(page,title){
+	let thisGroup = new Adw.PreferencesGroup({ title: title});
+	page.add(thisGroup);
+	return thisGroup;
 }
 
 function buildActionRow(labelstring,labeltooltip){

--- a/prefs.js
+++ b/prefs.js
@@ -438,11 +438,9 @@ function buildResetButton(setting){
 		visible: false
 	});
 
-	//hide if default setting
-	if (settings.get_user_value(setting) != null){
-		if(settings.get_user_value(setting).print(true) != settings.get_default_value(setting).print(true))
+	//hide if matches default setting
+	if (settings.get_value(setting).print(true) != settings.get_default_value(setting).print(true))
 			thisResetButton.set_visible(true);
-	}
 
 	thisResetButton.add_css_class('flat');
 	thisResetButton.set_tooltip_text('Reset to Default');

--- a/prefs.js
+++ b/prefs.js
@@ -126,15 +126,15 @@ function fillPreferencesWindow(window){
 	scrollDropDown.set_size_request(140,-1); //match size with next button
 
 	group = addGroup(page,'Behaviour');
-	let VolumeControlDropDown = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
-	VolumeControlDropDown.set_size_request(140,-1); //match size with previous button
+	let volumeControlDropDown = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
+	volumeControlDropDown.set_size_request(140,-1); //match size with previous button
 
 	addResetButton(group,'Reset Controls settings',[
 		'enable-double-clicks','double-click-time','left-click-action','left-double-click-action','middle-click-action','middle-double-click-action',
 		'right-click-action','right-double-click-action','scroll-action','thumb-forward-action','thumb-double-forward-action','thumb-backward-action',
 		'thumb-double-backward-action','volume-control-scheme'],[leftClickDropDown, leftDoubleClickDropDown,middleClickDropDown, middleDoubleClickDropDown,
 		rightClickDropDown, rightDoubleClickDropDown,thumbForwardDropDown, thumbDoubleForwardDropDown,thumbBackwardDropDown, thumbDoubleBackwardDropDown,
-		scrollDropDown,VolumeControlDropDown]
+		scrollDropDown,volumeControlDropDown]
 	);
 
 	[doubleClickTime, doubleClickLabel, leftDoubleClickDropDown, middleDoubleClickDropDown, rightDoubleClickDropDown, thumbDoubleForwardDropDown, thumbDoubleBackwardDropDown]

--- a/prefs.js
+++ b/prefs.js
@@ -164,7 +164,7 @@ function addGroup(page,title){
 function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let resetButton = buildResetButton(setting);
+	let thisResetButton = buildResetButton(setting);
 
 	let thisSpinButton = new Gtk.SpinButton({
 		adjustment: new Gtk.Adjustment({
@@ -178,14 +178,14 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	});
 	settings.bind(setting,thisSpinButton,'value',Gio.SettingsBindFlags.DEFAULT);
 
-	row.add_suffix(resetButton);
+	row.add_suffix(thisResetButton);
 	row.add_suffix(thisSpinButton);
 
 	thisSpinButton.connect('changed',() => {
 		if (thisSpinButton.text == settings.get_default_value(setting).print(true))
-			resetButton.set_visible(false)
+			thisResetButton.set_visible(false)
 		else
-			resetButton.set_visible(true)
+			thisResetButton.set_visible(true)
 	})
 
 	group.add(row);
@@ -300,8 +300,8 @@ function setDropDownResetVisibility(settingsList,dropDownList,optionsList){ //sh
 function addSwitch(group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let resetButton = buildResetButton(setting);
-	row.add_suffix(resetButton);
+	let thisResetButton = buildResetButton(setting);
+	row.add_suffix(thisResetButton);
 
 	let thisSwitch = new Gtk.Switch({
 		valign: Gtk.Align.CENTER,
@@ -313,9 +313,9 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 
 	thisSwitch.connect('notify::active',() => {
 		if (thisSwitch.state == (settings.get_default_value(setting).print(true) === "true"))
-			resetButton.set_visible(false);
+			thisResetButton.set_visible(false);
 		else
-			resetButton.set_visible(true)
+			thisResetButton.set_visible(true)
 	})
 
 	group.add(row)
@@ -324,8 +324,8 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 function addEntry(group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let resetButton = buildResetButton(setting);
-	row.add_suffix(resetButton);
+	let thisResetButton = buildResetButton(setting);
+	row.add_suffix(thisResetButton);
 
 	let thisEntry = new Gtk.Entry({
 		valign: Gtk.Align.CENTER,
@@ -338,9 +338,9 @@ function addEntry(group,setting,labelstring,labeltooltip){
 
 	thisEntry.connect('changed',() => {
 		if (thisEntry.text == settings.get_default_value(setting).print(true).replaceAll('\'', ''))
-			resetButton.set_visible(false);
+			thisResetButton.set_visible(false);
 		else
-			resetButton.set_visible(true)
+			thisResetButton.set_visible(true)
 	})
 
 	group.add(row)

--- a/prefs.js
+++ b/prefs.js
@@ -70,7 +70,7 @@ function fillPreferencesWindow(window){
 	group = new Adw.PreferencesGroup({ title: 'Appearance'});
 	page.add(group);
 	addSpinButton(group,'max-string-length','Max string length (each field)',1,150,undefined);
-	addEntry(group,'button-placeholder','Button placeholder (can be left empty)',"The button placeholder is a hint for the user\nAppears when the label is empty and another available source is active");
+	addEntry(group,'button-placeholder','Button placeholder',"The button placeholder is a hint for the user and can be left empty.\n\nIt appears when the label is empty and another available source is active");
 	addEntry(group,'divider-string','Divider string (you can use spaces)',undefined);
 
 	let fieldOptions1 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title'};
@@ -153,25 +153,25 @@ function fillPreferencesWindow(window){
 	row = new Adw.ActionRow({ title: ''});
 	let singleClickLabel = new Gtk.Label({ //not sure how to underline or reduce height
 		label: 'Single click',
-		width_chars: 17
+		width_chars: 15
 	});
 	row.add_suffix(singleClickLabel);
 	doubleClickLabel = new Gtk.Label({
 		label: 'Double click',
-		width_chars: 17
+		width_chars: 28
 	});
 	row.add_suffix(doubleClickLabel);
 	group.add(row);
 
-	let [leftClickComboBox, leftDoubleClickComboBox] = addDoubleStringComboBox(group,'left-click-action','left-double-click-action','Left click action',buttonActions,undefined);
-	let [middleClickComboBox, middleDoubleClickComboBox] = addDoubleStringComboBox(group,'middle-click-action','middle-double-click-action','Middle click action',buttonActions,undefined,);
-	let [rightClickComboBox, rightDoubleClickComboBox] = addDoubleStringComboBox(group,'right-click-action','right-double-click-action','Right click action',buttonActions,undefined);
-	let [thumbForwardComboBox, thumbDoubleForwardComboBox] = addDoubleStringComboBox(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button action',buttonActions,undefined);
-	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringComboBox(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button action',buttonActions,undefined);
+	let [leftClickComboBox, leftDoubleClickComboBox] = addDoubleStringComboBox(group,'left-click-action','left-double-click-action','Left click',buttonActions,undefined);
+	let [middleClickComboBox, middleDoubleClickComboBox] = addDoubleStringComboBox(group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,undefined,);
+	let [rightClickComboBox, rightDoubleClickComboBox] = addDoubleStringComboBox(group,'right-click-action','right-double-click-action','Right click',buttonActions,undefined);
+	let [thumbForwardComboBox, thumbDoubleForwardComboBox] = addDoubleStringComboBox(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,undefined);
+	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringComboBox(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
 
 	group = new Adw.PreferencesGroup({ title: ''});
 	page.add(group);
-	let scrollComboBox = addStringComboBox(group,'scroll-action','Scroll up/down action',{'volume control':'volume-controls','none':'none'},undefined);
+	let scrollComboBox = addStringComboBox(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
 	scrollComboBox.set_size_request(140,-1); //match size with next button
 
 	group = new Adw.PreferencesGroup({ title: 'Behaviour'});
@@ -258,6 +258,25 @@ function buildInfoButton(labeltooltip){
 	return thisInfoButton;
 }
 
+function buildResetButton(setting,combobox){
+	let thisResetButton = new Gtk.Button({
+		valign: Gtk.Align.CENTER,
+		icon_name: 'edit-clear-symbolic',
+		visible: true
+	});
+	thisResetButton.add_css_class('flat');
+	thisResetButton.set_tooltip_text('Reset to Default');
+	if (combobox)
+		thisResetButton.connect('clicked',() => {
+			settings.reset(setting);
+			combobox.set_active_id(settings.get_string(setting));
+		});
+	else
+		thisResetButton.connect('clicked',() => {settings.reset(setting)});
+
+	return thisResetButton;
+}
+
 function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
@@ -271,10 +290,12 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 		halign: Gtk.Align.END,
 		visible: true
 	});
-
 	settings.bind(setting,thisSpinButton,'value',Gio.SettingsBindFlags.DEFAULT);
-
 	row.add_suffix(thisSpinButton);
+
+	let resetButton = buildResetButton(setting);
+	row.add_suffix(resetButton);
+
 	group.add(row);
 	return thisSpinButton;
 }
@@ -283,8 +304,11 @@ function addStringComboBox(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
 	thisComboBox = buildStringComboBox(settings,setting,options);
-
 	row.add_suffix(thisComboBox);
+
+	let resetButton = buildResetButton(setting);
+	row.add_suffix(resetButton,thisComboBox);
+
 	group.add(row);
 
 	return thisComboBox //necessary to reset position when the reset button is clicked
@@ -295,9 +319,12 @@ function addDoubleStringComboBox(group, setting1, setting2, labelstring, options
 
 	comboBox1 = buildStringComboBox(settings, setting1, options);
 	row.add_suffix(comboBox1);
+	row.add_suffix(buildResetButton(setting1),comboBox1);
 
 	comboBox2 = buildStringComboBox(settings, setting2, options);
 	row.add_suffix(comboBox2);
+	row.add_suffix(buildResetButton(setting2),comboBox2);
+
 	group.add(row)
 
 	return [comboBox1, comboBox2]
@@ -328,8 +355,11 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 		visible: true
 	});
 	settings.bind(setting,thisSwitch,'active',Gio.SettingsBindFlags.DEFAULT);
-
 	row.add_suffix(thisSwitch);
+
+	let resetButton = buildResetButton(setting);
+	row.add_suffix(resetButton);
+
 	group.add(row)
 }
 
@@ -343,18 +373,27 @@ function addEntry(group,setting,labelstring,labeltooltip){
 		visible: true
 	});
 	settings.bind(setting,thisEntry,'text',Gio.SettingsBindFlags.DEFAULT);
-
 	row.add_suffix(thisEntry);
+
+	let resetButton = buildResetButton(setting);
+	row.add_suffix(resetButton);
+
 	group.add(row)
 }
 
 function addWideEntry(group,setting,placeholder,labeltooltip){
-	let thisEntry = new Gtk.Entry({ visible: true});
+	let thisEntry = new Gtk.Entry({ 
+		visible: true,
+		secondary_icon_name: "edit-clear-symbolic",
+		secondary_icon_tooltip_text: "Reset to Default"
+	});
 	if ( labeltooltip )
 		thisEntry.set_tooltip_text(labeltooltip)
 
-	if (setting)
+	if (setting){
 		settings.bind(setting,thisEntry,'text',Gio.SettingsBindFlags.DEFAULT);
+		thisEntry.connect('icon-press',() => {settings.reset(setting)});
+	}
 
 	thisEntry.set_placeholder_text(placeholder);
 	group.add(thisEntry);

--- a/prefs.js
+++ b/prefs.js
@@ -35,20 +35,10 @@ function fillPreferencesWindow(window){
 	addSpinButton(group,'reposition-delay','Panel reposition at startup (delay in seconds)',0,300,"Increase this value if extension index isn't respected at startup");
 	addSwitch(group,'reposition-on-button-press','Update panel position on every button press',undefined);
 
-	//Reset Button
-	addButton(group,'Reset Panel settings', () => {
-		settings.reset('show-icon');
-		settings.reset('left-padding');
-		settings.reset('right-padding');
-		settings.reset('extension-index');
-		settings.reset('extension-place');
-		settings.reset('reposition-delay');
-		settings.reset('reposition-on-button-press');
-		settings.reset('use-album');
-		settings.reset('album-size');
-		settings.reset('symbolic-source-icon');
-		settings.reset('icon-padding');
-	});
+	addResetButton(group,'Reset Panel settings',[
+		'show-icon','left-padding','right-padding','extension-index','extension-place','reposition-delay','reposition-on-button-press','use-album',
+		'album-size','symbolic-source-icon','icon-padding']
+	);
 
 //label page:
 	page = addPreferencesPage(window,'Label','document-edit-symbolic');
@@ -70,23 +60,10 @@ function fillPreferencesWindow(window){
 	let fieldOptions3 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
 	let [firstFieldComboBox, secondFieldComboBox, lastFieldComboBox] = addTripleStringDropDown(group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
 
-	//Reset Button
-	addButton(group,'Reset Label settings', () => {
-		settings.reset('max-string-length');
-		settings.reset('refresh-rate');
-		settings.reset('button-placeholder');
-		settings.reset('label-filtered-list');
-		settings.reset('divider-string');
-		settings.reset('first-field');
-		settings.reset('second-field');
-		settings.reset('last-field');
-		settings.reset('remove-text-when-paused');
-		settings.reset('remove-text-paused-delay');
-		settings.reset('auto-switch-to-most-recent');
-		firstFieldComboBox.set_active_id(settings.get_string('first-field'));
-		secondFieldComboBox.set_active_id(settings.get_string('second-field'));
-		lastFieldComboBox.set_active_id(settings.get_string('last-field'));
-	});
+	addResetButton(group,'Reset Label settings',[
+		'max-string-length','refresh-rate','button-placeholder','label-filtered-list','divider-string','first-field','second-field',
+		'last-field','remove-text-when-paused','remove-text-paused-delay','auto-switch-to-most-recent']
+	);
 
 //filters page:
 	page = addPreferencesPage(window,'Filters','dialog-error-symbolic');
@@ -112,13 +89,9 @@ function fillPreferencesWindow(window){
 	group = addGroup(page,'Players excluded from using album art as icon');
 	addWideEntry(group,'album-blacklist','Separate entries with commas',undefined);
 
-	//Reset Button
-	addButton(group,'Reset Filters settings', () => {
-		settings.reset('mpris-sources-blacklist');
-		settings.reset('mpris-sources-whitelist');
-		settings.reset('use-whitelisted-sources-only');
-		settings.reset('album-blacklist');
-	});
+	addResetButton(group,'Reset Filters settings',[
+		'mpris-sources-blacklist','mpris-sources-whitelist','use-whitelisted-sources-only','album-blacklist']
+	);
 
 //controls page:
 	page = addPreferencesPage(window,'Controls','input-mouse-symbolic');
@@ -161,35 +134,11 @@ function fillPreferencesWindow(window){
 	let VolumeControlComboBox = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
 	VolumeControlComboBox.set_size_request(140,-1); //match size with previous button
 
-	//Reset Button
-	addButton(group,'Reset Controls settings',() => {
-		settings.reset('enable-double-clicks');
-		settings.reset('double-click-time');
-		settings.reset('left-click-action');
-		settings.reset('left-double-click-action');
-		settings.reset('middle-click-action');
-		settings.reset('middle-double-click-action');
-		settings.reset('right-click-action');
-		settings.reset('right-double-click-action');
-		settings.reset('scroll-action');
-		settings.reset('thumb-forward-action');
-		settings.reset('thumb-double-forward-action');
-		settings.reset('thumb-backward-action');
-		settings.reset('thumb-double-backward-action');
-		settings.reset('volume-control-scheme');
-		leftClickComboBox.set_active_id(settings.get_string('left-click-action'));
-		leftDoubleClickComboBox.set_active_id(settings.get_string('left-double-click-action'));
-		middleClickComboBox.set_active_id(settings.get_string('middle-click-action'));
-		middleDoubleClickComboBox.set_active_id(settings.get_string('middle-double-click-action'));
-		rightClickComboBox.set_active_id(settings.get_string('right-click-action'));
-		rightDoubleClickComboBox.set_active_id(settings.get_string('right-double-click-action'));
-		scrollComboBox.set_active_id(settings.get_string('scroll-action'));
-		thumbForwardComboBox.set_active_id(settings.get_string('thumb-forward-action'));
-		thumbDoubleForwardComboBox.set_active_id(settings.get_string('thumb-double-forward-action'));
-		thumbBackwardComboBox.set_active_id(settings.get_string('thumb-backward-action'));
-		thumbDoubleBackwardComboBox.set_active_id(settings.get_string('thumb-double-backward-action'));
-		VolumeControlComboBox.set_active_id(settings.get_string('volume-control-scheme'));
-	});
+	addResetButton(group,'Reset Controls settings',[
+		'enable-double-clicks','double-click-time','left-click-action','left-double-click-action','middle-click-action','middle-double-click-action',
+		'right-click-action','right-double-click-action','scroll-action','thumb-forward-action','thumb-double-forward-action','thumb-backward-action',
+		'thumb-double-backward-action','volume-control-scheme']
+	);
 
 	[doubleClickTime, doubleClickLabel, leftDoubleClickComboBox, middleDoubleClickComboBox, rightDoubleClickComboBox, thumbDoubleForwardComboBox, thumbDoubleBackwardComboBox]
 		.forEach(el => bindEnabled(settings, 'enable-double-clicks', el));
@@ -394,16 +343,22 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 	return thisEntry;
 }
 
-function addButton(group,labelstring,callback){
-	button = new Gtk.Button({
-		label: labelstring,
-		margin_top: 30,
-		visible: true
+function addResetButton(group,labelstring,options){
+	let thisButton = buildButton(labelstring, () => {
+		options.forEach(option => {
+			settings.reset(option);
+		});
 	});
-	button.connect('clicked',callback);
-	group.add(button);
 
-	return button
+	group.add(thisButton);
+
+	return thisButton;
+}
+
+function addButton(group,labelstring,callback){
+	let thisButton = buildButton(labelstring,callback);
+	group.add(thisButton);
+	return thisButton;
 }
 
 // 'build' functions, they build "generic" widgets for the specified type and returns it
@@ -521,7 +476,18 @@ function buildStringDropDown(settings,setting,options,width){
 		settings.set_string(setting,thisComboBox.get_active_id());
 	});
 
-	return thisComboBox
+	return thisComboBox;
+}
+
+function buildButton(labelstring,callback){
+	let button = new Gtk.Button({
+		label: labelstring,
+		margin_top: 30,
+		visible: true
+	});
+	button.connect('clicked',callback);
+
+	return button;
 }
 
 // helper functions

--- a/prefs.js
+++ b/prefs.js
@@ -254,11 +254,12 @@ function buildResetButton(setting){
 	});
 
 	//hide if default setting
-	if (settings.get_string(setting))
-		thisResetButton.set_visible(true);
+	if (settings.get_user_value(setting) != null)
+		thisResetButton.set_visible(true)
 
 	thisResetButton.add_css_class('flat');
 	thisResetButton.set_tooltip_text('Reset to Default');
+
 	thisResetButton.connect('clicked',() => {
 		settings.reset(setting);
 		thisResetButton.set_visible(false)
@@ -305,10 +306,6 @@ function buildDropDown(settings,setting,options,width){
 	if (width)
 		thisDropDown.set_size_request(width,-1);
 
-	// thisDropDown.connect('notify::selected-item', () => {
-	// 	settings.set_string(setting,'right');
-	// });
-
 	return thisDropDown;
 }
 
@@ -321,12 +318,12 @@ function buildDropDownResetButton(setting,combobox,options){
 
 	//hide if default setting
 	setting.forEach((item) => {
-		if (settings.get_string(item))
+		if (settings.get_user_value(item) != null && settings.get_user_value(item) != settings.get_default_value(item))
 			thisResetButton.set_visible(true);
 	})
 
 	thisResetButton.add_css_class('flat');
-	thisResetButton.set_tooltip_text('Reset to Default');
+	// thisResetButton.set_tooltip_text('Reset to Default');
 
 	thisResetButton.connect('clicked',() => {
 		 for (let i = 0; i < setting.length; i++) {

--- a/prefs.js
+++ b/prefs.js
@@ -355,7 +355,7 @@ function addButton(group,labelstring,callback){
 	return thisButton;
 }
 
-// 'build' functions, they build "generic" widgets for the specified type and returns it
+// 'build' functions, they build "generic" widgets of the specified type and returns it
 
 function buildActionRow(labelstring,labeltooltip){
 	let row = new Adw.ActionRow({ title: labelstring });
@@ -451,26 +451,6 @@ function buildDropDownResetButton(setting,combobox,options){
 	});
 
 	return thisResetButton;
-}
-
-function buildStringDropDown(settings,setting,options,width){
-	let thisComboBox = new Gtk.ComboBoxText({//consider using Adw.ComboRow
-		valign: Gtk.Align.CENTER,
-		halign: Gtk.Align.END,
-		visible: true
-	});
-	if (width)
-		thisComboBox.set_size_request(105,-1);
-
-	for (let option in options){
-		thisComboBox.append(options[option],option);
-	}
-	thisComboBox.set_active_id(settings.get_string(setting));
-	thisComboBox.connect('changed', () => {
-		settings.set_string(setting,thisComboBox.get_active_id());
-	});
-
-	return thisComboBox;
 }
 
 function buildButton(labelstring,callback){

--- a/prefs.js
+++ b/prefs.js
@@ -262,17 +262,27 @@ function buildResetButton(setting,combobox){
 	let thisResetButton = new Gtk.Button({
 		valign: Gtk.Align.CENTER,
 		icon_name: 'edit-clear-symbolic',
-		visible: true
+		visible: false
 	});
+
+	//hide if default setting
+	if (settings.get_string(setting))
+		thisResetButton.set_visible(true);
+
 	thisResetButton.add_css_class('flat');
 	thisResetButton.set_tooltip_text('Reset to Default');
 	if (combobox)
 		thisResetButton.connect('clicked',() => {
 			settings.reset(setting);
 			combobox.set_active_id(settings.get_string(setting));
+			thisResetButton.set_visible(false);
 		});
-	else
-		thisResetButton.connect('clicked',() => {settings.reset(setting)});
+	else {
+		thisResetButton.connect('clicked',() => {
+			settings.reset(setting);
+			thisResetButton.set_visible(false)
+		});
+	}
 
 	return thisResetButton;
 }
@@ -296,6 +306,8 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	let resetButton = buildResetButton(setting);
 	row.add_suffix(resetButton);
 
+	thisSpinButton.connect('changed',() => {resetButton.set_visible(true)})
+
 	group.add(row);
 	return thisSpinButton;
 }
@@ -309,6 +321,7 @@ function addStringComboBox(group,setting,labelstring,options,labeltooltip){
 	let resetButton = buildResetButton(setting);
 	row.add_suffix(resetButton,thisComboBox);
 
+	thisComboBox.connect('changed',() => {resetButton.set_visible(true)})
 	group.add(row);
 
 	return thisComboBox //necessary to reset position when the reset button is clicked
@@ -360,6 +373,8 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 	let resetButton = buildResetButton(setting);
 	row.add_suffix(resetButton);
 
+	thisSwitch.connect('state-set',() => {resetButton.set_visible(true)})
+
 	group.add(row)
 }
 
@@ -384,7 +399,7 @@ function addEntry(group,setting,labelstring,labeltooltip){
 function addWideEntry(group,setting,placeholder,labeltooltip){
 	let thisEntry = new Gtk.Entry({ 
 		visible: true,
-		secondary_icon_name: "edit-clear-symbolic",
+		secondary_icon_name: '',
 		secondary_icon_tooltip_text: "Reset to Default"
 	});
 	if ( labeltooltip )
@@ -392,7 +407,15 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 
 	if (setting){
 		settings.bind(setting,thisEntry,'text',Gio.SettingsBindFlags.DEFAULT);
-		thisEntry.connect('icon-press',() => {settings.reset(setting)});
+		thisEntry.connect('icon-press',() => {
+			thisEntry.set_icon_from_icon_name(1,'');
+			settings.reset(setting)
+		});
+
+		thisEntry.connect('changed',() => {	thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');	})
+
+		if (settings.get_string(setting))
+			thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');
 	}
 
 	thisEntry.set_placeholder_text(placeholder);

--- a/prefs.js
+++ b/prefs.js
@@ -181,7 +181,12 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	row.add_suffix(resetButton);
 	row.add_suffix(thisSpinButton);
 
-	thisSpinButton.connect('changed',() => {resetButton.set_visible(true)})
+	thisSpinButton.connect('changed',() => {
+		if (thisSpinButton.text == settings.get_default_value(setting).print(true))
+			resetButton.set_visible(false)
+		else
+			resetButton.set_visible(true)
+	})
 
 	group.add(row);
 	return row;
@@ -282,8 +287,8 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 	settings.bind(setting,thisSwitch,'active',Gio.SettingsBindFlags.DEFAULT);
 	row.add_suffix(thisSwitch);
 
-	thisSwitch.connect('state-set',() => {
-		if (settings.get_boolean(setting) == Boolean(settings.get_default_value(setting)))
+	thisSwitch.connect('notify::active',() => {
+		if (thisSwitch.state == (settings.get_default_value(setting).print(true) === "true"))
 			resetButton.set_visible(false);
 		else
 			resetButton.set_visible(true)
@@ -307,7 +312,12 @@ function addEntry(group,setting,labelstring,labeltooltip){
 	settings.bind(setting,thisEntry,'text',Gio.SettingsBindFlags.DEFAULT);
 	row.add_suffix(thisEntry);
 
-	thisEntry.connect('changed',() => {resetButton.set_visible(true)})
+	thisEntry.connect('changed',() => {
+		if (thisEntry.text == settings.get_default_value(setting).print(true).replaceAll('\'', ''))
+			resetButton.set_visible(false);
+		else
+			resetButton.set_visible(true)
+	})
 
 	group.add(row)
 }
@@ -410,8 +420,10 @@ function buildResetButton(setting){
 	});
 
 	//hide if default setting
-	if (settings.get_user_value(setting) != null)
-		thisResetButton.set_visible(true)
+	if (settings.get_user_value(setting) != null){
+		if(settings.get_user_value(setting).print(true) != settings.get_default_value(setting).print(true))
+			thisResetButton.set_visible(true);
+	}
 
 	thisResetButton.add_css_class('flat');
 	thisResetButton.set_tooltip_text('Reset to Default');

--- a/prefs.js
+++ b/prefs.js
@@ -316,7 +316,7 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 function addStringComboBox(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	thisComboBox = buildStringComboBox(settings,setting,options);
+	thisComboBox = buildStringComboBox(settings,setting,options,105); //105 preferred width to align with spinbuttons
 	let resetButton = buildResetButton(setting);
 
 	row.add_suffix(resetButton,thisComboBox);
@@ -427,13 +427,15 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 	return thisEntry;
 }
 
-function buildStringComboBox(settings,setting,options){
+function buildStringComboBox(settings,setting,options,width){
 	let thisComboBox = new Gtk.ComboBoxText({//consider using Adw.ComboRow
 		valign: Gtk.Align.CENTER,
 		halign: Gtk.Align.END,
-		width_request: 105,
 		visible: true
 	});
+	if (width)
+		thisComboBox.set_size_request(105,-1);
+
 	for (let option in options){
 		thisComboBox.append(options[option],option);
 	}

--- a/prefs.js
+++ b/prefs.js
@@ -291,7 +291,7 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	thisSpinButton.connect('changed',() => {resetButton.set_visible(true)})
 
 	group.add(row);
-	return thisSpinButton;
+	return row;
 }
 
 function buildDropDown(settings,setting,options,width){
@@ -323,7 +323,7 @@ function buildDropDownResetButton(setting,combobox,options){
 	})
 
 	thisResetButton.add_css_class('flat');
-	// thisResetButton.set_tooltip_text('Reset to Default');
+	thisResetButton.set_tooltip_text('Reset to Default');
 
 	thisResetButton.connect('clicked',() => {
 		 for (let i = 0; i < setting.length; i++) {
@@ -431,7 +431,12 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 	settings.bind(setting,thisSwitch,'active',Gio.SettingsBindFlags.DEFAULT);
 	row.add_suffix(thisSwitch);
 
-	thisSwitch.connect('state-set',() => {resetButton.set_visible(true)})
+	thisSwitch.connect('state-set',() => {
+		if (settings.get_boolean(setting) == Boolean(settings.get_default_value(setting)))
+			resetButton.set_visible(false);
+		else 
+			resetButton.set_visible(true)
+	})
 
 	group.add(row)
 }
@@ -552,6 +557,6 @@ function playersToString(){
 }
 
 function bindEnabled(settings, setting, element) {
-	settings.bind(setting, element, 'sensitive', Gio.SettingsBindFlags.GET);
+	settings.bind(setting, element, 'visible', Gio.SettingsBindFlags.GET);
 }
 

--- a/prefs.js
+++ b/prefs.js
@@ -19,14 +19,14 @@ function fillPreferencesWindow(window){
 	page = addPreferencesPage(window,'Panel','computer-symbolic');
 
 	group = addGroup(page,'Icon');
-	let showIconComboBox = addStringComboBox(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
+	let showIconComboBox = addStringComboRow(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
 	addSpinButton(group, 'icon-padding', 'Icon padding', 0, 50, undefined);
 	addSwitch(group, 'symbolic-source-icon', 'Use symbolic source icon', "Uses an icon that follows the shell's color scheme");
 	addSwitch(group,'use-album','Use album art as icon when available',undefined);
 	addSpinButton(group,'album-size','Album art scaling (in %)',20,250,undefined);
 
 	group = addGroup(page,'Position');
-	let extensionPlaceComboBox = addStringComboBox(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
+	let extensionPlaceComboBox = addStringComboRow(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
 	addSpinButton(group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
 	addSpinButton(group,'left-padding','Left padding',0,500,undefined);
 	addSpinButton(group,'right-padding','Right padding',0,500,undefined);
@@ -48,8 +48,6 @@ function fillPreferencesWindow(window){
 		settings.reset('album-size');
 		settings.reset('symbolic-source-icon');
 		settings.reset('icon-padding');
-		extensionPlaceComboBox.set_active_id(settings.get_string('extension-place'));
-		showIconComboBox.set_active_id(settings.get_string('show-icon'));
 	});
 
 //label page:
@@ -301,6 +299,30 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 
 	group.add(row);
 	return thisSpinButton;
+}
+
+function addStringComboRow(group,setting,labelstring,options,labeltooltip){
+	let row = buildActionRow(labelstring,labeltooltip);
+
+	let thisComboRow = new Adw.ComboRow({
+		model: Gtk.StringList.new(Object.keys(options)),
+		selected: Object.keys(options).indexOf(settings.get_string(setting)),
+		valign: Gtk.Align.END
+	});
+
+	let resetButton = buildResetButton(setting);
+
+	row.add_suffix(resetButton);
+	row.add_suffix(thisComboRow);
+
+	thisComboRow.connect('notify::selected-item', () => {
+		settings.set_string(setting,Object.values(options)[thisComboRow.get_selected().id]);
+		resetButton.set_visible(true);
+	});
+
+	group.add(row);
+
+	return thisComboRow;
 }
 
 function addStringComboBox(group,setting,labelstring,options,labeltooltip){

--- a/prefs.js
+++ b/prefs.js
@@ -261,7 +261,7 @@ function buildInfoButton(labeltooltip){
 function buildResetButton(setting,combobox){
 	let thisResetButton = new Gtk.Button({
 		valign: Gtk.Align.CENTER,
-		icon_name: 'edit-clear-symbolic',
+		icon_name: 'edit-clear-symbolic-rtl',
 		visible: false
 	});
 
@@ -290,6 +290,8 @@ function buildResetButton(setting,combobox){
 function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
+	let resetButton = buildResetButton(setting);
+
 	let thisSpinButton = new Gtk.SpinButton({
 		adjustment: new Gtk.Adjustment({
 			lower: lower,
@@ -301,10 +303,9 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 		visible: true
 	});
 	settings.bind(setting,thisSpinButton,'value',Gio.SettingsBindFlags.DEFAULT);
-	row.add_suffix(thisSpinButton);
 
-	let resetButton = buildResetButton(setting);
 	row.add_suffix(resetButton);
+	row.add_suffix(thisSpinButton);
 
 	thisSpinButton.connect('changed',() => {resetButton.set_visible(true)})
 
@@ -316,10 +317,10 @@ function addStringComboBox(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
 	thisComboBox = buildStringComboBox(settings,setting,options);
-	row.add_suffix(thisComboBox);
-
 	let resetButton = buildResetButton(setting);
+
 	row.add_suffix(resetButton,thisComboBox);
+	row.add_suffix(thisComboBox);
 
 	thisComboBox.connect('changed',() => {resetButton.set_visible(true)})
 	group.add(row);
@@ -331,12 +332,12 @@ function addDoubleStringComboBox(group, setting1, setting2, labelstring, options
 	let row = buildActionRow(labelstring,labeltooltip);
 
 	comboBox1 = buildStringComboBox(settings, setting1, options);
-	row.add_suffix(comboBox1);
 	row.add_suffix(buildResetButton(setting1),comboBox1);
+	row.add_suffix(comboBox1);
 
 	comboBox2 = buildStringComboBox(settings, setting2, options);
-	row.add_suffix(comboBox2);
 	row.add_suffix(buildResetButton(setting2),comboBox2);
+	row.add_suffix(comboBox2);
 
 	group.add(row)
 
@@ -362,6 +363,9 @@ function addTripleStringComboBox(group, setting1, setting2, setting3, labelstrin
 function addSwitch(group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
+	let resetButton = buildResetButton(setting);
+	row.add_suffix(resetButton);
+
 	let thisSwitch = new Gtk.Switch({
 		valign: Gtk.Align.CENTER,
 		halign: Gtk.Align.END,
@@ -370,9 +374,6 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 	settings.bind(setting,thisSwitch,'active',Gio.SettingsBindFlags.DEFAULT);
 	row.add_suffix(thisSwitch);
 
-	let resetButton = buildResetButton(setting);
-	row.add_suffix(resetButton);
-
 	thisSwitch.connect('state-set',() => {resetButton.set_visible(true)})
 
 	group.add(row)
@@ -380,6 +381,9 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 
 function addEntry(group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
+
+	let resetButton = buildResetButton(setting);
+	row.add_suffix(resetButton);
 
 	let thisEntry = new Gtk.Entry({
 		valign: Gtk.Align.CENTER,
@@ -390,8 +394,7 @@ function addEntry(group,setting,labelstring,labeltooltip){
 	settings.bind(setting,thisEntry,'text',Gio.SettingsBindFlags.DEFAULT);
 	row.add_suffix(thisEntry);
 
-	let resetButton = buildResetButton(setting);
-	row.add_suffix(resetButton);
+	thisEntry.connect('changed',() => {resetButton.set_visible(true)})
 
 	group.add(row)
 }

--- a/prefs.js
+++ b/prefs.js
@@ -328,7 +328,12 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 			settings.reset(setting)
 		});
 
-		thisEntry.connect('changed',() => {	thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');	})
+		thisEntry.connect('changed',() => {
+			if (settings.get_string(setting)) //default for WideEntry is to be empty
+				thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');	
+			else
+				thisEntry.set_icon_from_icon_name(1,'');
+		})
 
 		if (settings.get_string(setting))
 			thisEntry.set_icon_from_icon_name(1,'edit-clear-symbolic');

--- a/prefs.js
+++ b/prefs.js
@@ -137,12 +137,12 @@ function fillPreferencesWindow(window){
 	row = new Adw.ActionRow({ title: ''});
 	let singleClickLabel = new Gtk.Label({ //not sure how to underline or reduce height
 		label: 'Single click',
-		width_chars: 15
+		width_chars: 17
 	});
 	row.add_suffix(singleClickLabel);
 	doubleClickLabel = new Gtk.Label({
 		label: 'Double click',
-		width_chars: 28
+		width_chars: 17
 	});
 	row.add_suffix(doubleClickLabel);
 	group.add(row);
@@ -301,7 +301,7 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	return thisSpinButton;
 }
 
-function buildStringComboRow(settings,setting,options,width){
+function buildDropDown(settings,setting,options,width){
 
 	let thisDropDown = new Gtk.DropDown({
 		model: Gtk.StringList.new(Object.keys(options)),
@@ -311,7 +311,7 @@ function buildStringComboRow(settings,setting,options,width){
 	});
 
 	if (width)
-		thisDropDown.set_size_request(105,-1);
+		thisDropDown.set_size_request(width,-1);
 
 	// thisDropDown.connect('notify::selected-item', () => {
 	// 	settings.set_string(setting,'right');
@@ -323,7 +323,7 @@ function buildStringComboRow(settings,setting,options,width){
 function addStringComboRow(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let thisComboRow = buildStringComboRow(settings,setting,options,105)
+	let thisComboRow = buildDropDown(settings,setting,options,105)
 
 	let thisResetButton = new Gtk.Button({
 		valign: Gtk.Align.CENTER,
@@ -358,30 +358,14 @@ function addStringComboRow(group,setting,labelstring,options,labeltooltip){
 	return thisComboRow;
 }
 
-function addStringComboBox(group,setting,labelstring,options,labeltooltip){
-	let row = buildActionRow(labelstring,labeltooltip);
-
-	thisComboBox = buildStringComboBox(settings,setting,options,105); //105 preferred width to align with spinbuttons
-	let resetButton = buildResetButton(setting);
-
-	row.add_suffix(resetButton,thisComboBox);
-	row.add_suffix(thisComboBox);
-
-	thisComboBox.connect('changed',() => {resetButton.set_visible(true)})
-	group.add(row);
-
-	return thisComboBox //necessary to reset position when the reset button is clicked
-}
-
 function addDoubleStringComboBox(group, setting1, setting2, labelstring, options, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
+	let width = 135;
 
-	comboBox1 = buildStringComboBox(settings, setting1, options);
-	row.add_suffix(buildResetButton(setting1),comboBox1);
+	comboBox1 = buildDropDown(settings, setting1, options,width);
 	row.add_suffix(comboBox1);
 
-	comboBox2 = buildStringComboBox(settings, setting2, options);
-	row.add_suffix(buildResetButton(setting2),comboBox2);
+	comboBox2 = buildDropDown(settings, setting2, options,width);
 	row.add_suffix(comboBox2);
 
 	group.add(row)
@@ -391,14 +375,15 @@ function addDoubleStringComboBox(group, setting1, setting2, labelstring, options
 
 function addTripleStringComboBox(group, setting1, setting2, setting3, labelstring, options1, options2, options3, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
+	let width = 85;
 
-	comboBox1 = buildStringComboBox(settings, setting1, options1);
+	comboBox1 = buildDropDown(settings, setting1, options1,width);
 	row.add_suffix(comboBox1);
 
-	comboBox2 = buildStringComboBox(settings, setting2, options2);
+	comboBox2 = buildDropDown(settings, setting2, options2,width);
 	row.add_suffix(comboBox2);
 
-	comboBox3 = buildStringComboBox(settings, setting3, options3);
+	comboBox3 = buildDropDown(settings, setting3, options3,width);
 	row.add_suffix(comboBox3);
 
 	group.add(row)

--- a/prefs.js
+++ b/prefs.js
@@ -196,44 +196,44 @@ function addDropDown(group,setting,labelstring,options,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 105;
 
-	let thisComboRow = buildDropDown(settings,setting,options,width)
+	let thisDropDownRow = buildDropDown(settings,setting,options,width)
 
-	let thisResetButton = buildDropDownResetButton([setting],[thisComboRow],[options])
+	let thisResetButton = buildDropDownResetButton([setting],[thisDropDownRow],[options])
 
-	thisComboRow.connect('notify::selected-item', () => {
-		let dropDownValue = Object.values(options)[thisComboRow.get_selected()]
+	thisDropDownRow.connect('notify::selected-item', () => {
+		let dropDownValue = Object.values(options)[thisDropDownRow.get_selected()]
 		settings.set_string(setting,dropDownValue);
-		let setVisible = setComboResetVisibility([setting],[thisComboRow],[options]);
+		let setVisible = setDropDownResetVisibility([setting],[thisDropDownRow],[options]);
 		thisResetButton.set_visible(setVisible)
 	});
 
 	row.add_suffix(thisResetButton);
-	row.add_suffix(thisComboRow);
+	row.add_suffix(thisDropDownRow);
 
 	group.add(row);
 
-	return thisComboRow;
+	return thisDropDownRow;
 }
 
 function addDoubleStringDropDown(group, setting1, setting2, labelstring, options, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 135;
 
-	let comboBox1 = buildDropDown(settings, setting1, options, width);
-	let comboBox2 = buildDropDown(settings, setting2, options, width);
-	let thisResetButton = buildDropDownResetButton([setting1,setting2],[comboBox1,comboBox2],[options,options])
+	let dropDown1 = buildDropDown(settings, setting1, options, width);
+	let dropDown2 = buildDropDown(settings, setting2, options, width);
+	let thisResetButton = buildDropDownResetButton([setting1,setting2],[dropDown1,dropDown2],[options,options])
 
-	comboBox1.connect('notify::selected-item', () => {
-		let dropDownValue = Object.values(options)[comboBox1.get_selected()];
+	dropDown1.connect('notify::selected-item', () => {
+		let dropDownValue = Object.values(options)[dropDown1.get_selected()];
 		settings.set_string(setting1,dropDownValue);
-		let setVisible = setComboResetVisibility([setting1,setting2],[comboBox1,comboBox2],[options,options]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2],[dropDown1,dropDown2],[options,options]);
 		thisResetButton.set_visible(setVisible)
 	});
 
-	comboBox2.connect('notify::selected-item', () => {
-		let dropDownValue = Object.values(options)[comboBox2.get_selected()];
+	dropDown2.connect('notify::selected-item', () => {
+		let dropDownValue = Object.values(options)[dropDown2.get_selected()];
 		settings.set_string(setting2,dropDownValue);
-		let setVisible = setComboResetVisibility([setting1,setting2],[comboBox1,comboBox2],[options,options]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2],[dropDown1,dropDown2],[options,options]);
 		thisResetButton.set_visible(setVisible)
 		// //hide reset button if both values match default
 		// if (dropDownValue1 == settings.get_default_value(setting1).print(true).replaceAll('\'', '') && dropDownValue2 == settings.get_default_value(setting2).print(true).replaceAll('\'', ''))
@@ -243,51 +243,51 @@ function addDoubleStringDropDown(group, setting1, setting2, labelstring, options
 	});
 
 	row.add_suffix(thisResetButton);
-	row.add_suffix(comboBox1);
-	row.add_suffix(comboBox2);
+	row.add_suffix(dropDown1);
+	row.add_suffix(dropDown2);
 
 	group.add(row)
 
-	return [comboBox1, comboBox2]
+	return [dropDown1, dropDown2]
 }
 
 function addTripleStringDropDown(group, setting1, setting2, setting3, labelstring, options1, options2, options3, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 81;
 
-	let comboBox1 = buildDropDown(settings, setting1, options1,width);
-	let comboBox2 = buildDropDown(settings, setting2, options2,width);
-	let comboBox3 = buildDropDown(settings, setting3, options3,width);
-	let thisResetButton = buildDropDownResetButton([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3])
+	let dropDown1 = buildDropDown(settings, setting1, options1,width);
+	let dropDown2 = buildDropDown(settings, setting2, options2,width);
+	let dropDown3 = buildDropDown(settings, setting3, options3,width);
+	let thisResetButton = buildDropDownResetButton([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3])
 
-	comboBox1.connect('notify::selected-item', () => {
-		settings.set_string(setting1,Object.values(options1)[comboBox1.get_selected()]);
-		let setVisible = setComboResetVisibility([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3]);
+	dropDown1.connect('notify::selected-item', () => {
+		settings.set_string(setting1,Object.values(options1)[dropDown1.get_selected()]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3]);
 		thisResetButton.set_visible(setVisible)
 	});
 
-	comboBox2.connect('notify::selected-item', () => {
-		settings.set_string(setting2,Object.values(options2)[comboBox2.get_selected()]);
-		let setVisible = setComboResetVisibility([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3]);
+	dropDown2.connect('notify::selected-item', () => {
+		settings.set_string(setting2,Object.values(options2)[dropDown2.get_selected()]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3]);
 		thisResetButton.set_visible(setVisible)
 	});
 
-	comboBox3.connect('notify::selected-item', () => {
-		settings.set_string(setting3,Object.values(options3)[comboBox3.get_selected()]);
-		let setVisible = setComboResetVisibility([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3]);
+	dropDown3.connect('notify::selected-item', () => {
+		settings.set_string(setting3,Object.values(options3)[dropDown3.get_selected()]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3]);
 		thisResetButton.set_visible(setVisible)
 	});
 
 	row.add_suffix(thisResetButton);
-	row.add_suffix(comboBox1);
-	row.add_suffix(comboBox2);
-	row.add_suffix(comboBox3);
+	row.add_suffix(dropDown1);
+	row.add_suffix(dropDown2);
+	row.add_suffix(dropDown3);
 
 	group.add(row)
-	return [comboBox1, comboBox2, comboBox3]
+	return [dropDown1, dropDown2, dropDown3]
 }
 
-function setComboResetVisibility(settingsList,dropDownList,optionsList){ //show reset button if any of the values is different from default
+function setDropDownResetVisibility(settingsList,dropDownList,optionsList){ //show reset button if any of the values is different from default
 	let setVisible = false;
 	for (let i = 0; i < dropDownList.length; i++) {
 		let dropDownValue = Object.values(optionsList[i])[dropDownList[i].get_selected()];
@@ -476,7 +476,7 @@ function buildDropDown(settings,setting,options,width){
 	return thisDropDown;
 }
 
-function buildDropDownResetButton(setting,combobox,options){
+function buildDropDownResetButton(setting,dropDown,options){
 	let thisResetButton = new Gtk.Button({
 		valign: Gtk.Align.CENTER,
 		icon_name: 'edit-clear-symbolic-rtl',
@@ -495,7 +495,7 @@ function buildDropDownResetButton(setting,combobox,options){
 	thisResetButton.connect('clicked',() => {
 		 for (let i = 0; i < setting.length; i++) {
 			settings.reset(setting[i]);
-			combobox[i].set_selected(Object.values(options[i]).indexOf(settings.get_string(setting[i])));
+			dropDown[i].set_selected(Object.values(options[i]).indexOf(settings.get_string(setting[i])));
 		}
 		thisResetButton.set_visible(false);
 	});

--- a/prefs.js
+++ b/prefs.js
@@ -392,12 +392,28 @@ function addTripleStringComboBox(group, setting1, setting2, setting3, labelstrin
 	let width = 85;
 
 	let comboBox1 = buildDropDown(settings, setting1, options1,width);
-	row.add_suffix(comboBox1);
-
 	let comboBox2 = buildDropDown(settings, setting2, options2,width);
-	row.add_suffix(comboBox2);
-
 	let comboBox3 = buildDropDown(settings, setting3, options3,width);
+	let thisResetButton = buildDropDownResetButton([setting1,setting2,setting3],[comboBox1,comboBox2,comboBox3],[options1,options2,options3])
+
+	comboBox1.connect('notify::selected-item', () => {
+		settings.set_string(setting1,Object.values(options1)[comboBox1.get_selected()]);
+		thisResetButton.set_visible(true);
+	});
+
+	comboBox2.connect('notify::selected-item', () => {
+		settings.set_string(setting2,Object.values(options2)[comboBox2.get_selected()]);
+		thisResetButton.set_visible(true);
+	});
+
+	comboBox3.connect('notify::selected-item', () => {
+		settings.set_string(setting3,Object.values(options3)[comboBox3.get_selected()]);
+		thisResetButton.set_visible(true);
+	});
+
+	row.add_suffix(thisResetButton);
+	row.add_suffix(comboBox1);
+	row.add_suffix(comboBox2);
 	row.add_suffix(comboBox3);
 
 	group.add(row)

--- a/prefs.js
+++ b/prefs.js
@@ -31,7 +31,8 @@ function fillPreferencesWindow(window){
 
 	addResetButton(group,'Reset Panel settings',[
 		'show-icon','left-padding','right-padding','extension-index','extension-place','reposition-delay','reposition-on-button-press','use-album',
-		'album-size','symbolic-source-icon','icon-padding']
+		'album-size','symbolic-source-icon','icon-padding'],
+		[showIconDropDown,extensionPlaceDropDown]
 	);
 
 //label page:
@@ -337,12 +338,18 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 	return thisEntry;
 }
 
-function addResetButton(group,labelstring,options){
+function addResetButton(group,labelstring,options,dropDowns){
 	let thisButton = buildButton(labelstring, () => {
 		options.forEach(option => {
 			settings.reset(option);
 		});
 	});
+
+	if (dropDowns){
+		dropDowns.forEach(dropDown => {
+			dropDown.set_selected(dropDown._defaultValueIndex);
+		});
+	}
 
 	group.add(thisButton);
 
@@ -412,13 +419,14 @@ function buildResetButton(setting){
 }
 
 function buildDropDown(settings,setting,options,width){
-
 	let thisDropDown = new Gtk.DropDown({
 		model: Gtk.StringList.new(Object.keys(options)),
 		selected: Object.values(options).indexOf(settings.get_string(setting)),
 		valign: Gtk.Align.CENTER,
 		halign: Gtk.Align.END
 	});
+
+	thisDropDown._defaultValueIndex = Object.values(options).indexOf(settings.get_default_value(setting).get_string()[0]);
 
 	if (width)
 		thisDropDown.set_size_request(width,-1);

--- a/prefs.js
+++ b/prefs.js
@@ -447,10 +447,7 @@ function buildResetButton(setting){
 	thisResetButton.add_css_class('flat');
 	thisResetButton.set_tooltip_text('Reset to Default');
 
-	thisResetButton.connect('clicked',() => {
-		settings.reset(setting);
-		thisResetButton.set_visible(false)
-	});
+	thisResetButton.connect('clicked',() => {settings.reset(setting)});
 
 	return thisResetButton;
 }
@@ -492,7 +489,6 @@ function buildDropDownResetButton(setting,dropDown,options){
 			settings.reset(setting[i]);
 			dropDown[i].set_selected(Object.values(options[i]).indexOf(settings.get_string(setting[i])));
 		}
-		thisResetButton.set_visible(false);
 	});
 
 	return thisResetButton;

--- a/prefs.js
+++ b/prefs.js
@@ -7,26 +7,20 @@ const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-la
 function init(){}
 
 function fillPreferencesWindow(window){
-	// window.default_width = 650;
 	window.default_height = 950;
 
-	// const [major] = Config.PACKAGE_VERSION.split('.');
-	// const shellVersion = Number.parseInt(major);
-
-	let page,group;
-
 //panel page:
-	page = addPreferencesPage(window,'Panel','computer-symbolic');
+	let page = addPreferencesPage(window,'Panel','computer-symbolic');
 
-	group = addGroup(page,'Icon');
-	let showIconComboBox = addDropDown(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
+	let group = addGroup(page,'Icon');
+	let showIconDropDown = addDropDown(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
 	addSpinButton(group, 'icon-padding', 'Icon padding', 0, 50, undefined);
 	addSwitch(group, 'symbolic-source-icon', 'Use symbolic source icon', "Uses an icon that follows the shell's color scheme");
 	addSwitch(group,'use-album','Use album art as icon when available',undefined);
 	addSpinButton(group,'album-size','Album art scaling (in %)',20,250,undefined);
 
 	group = addGroup(page,'Position');
-	let extensionPlaceComboBox = addDropDown(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
+	let extensionPlaceDropDown = addDropDown(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
 	addSpinButton(group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
 	addSpinButton(group,'left-padding','Left padding',0,500,undefined);
 	addSpinButton(group,'right-padding','Right padding',0,500,undefined);
@@ -58,7 +52,7 @@ function fillPreferencesWindow(window){
 	let fieldOptions1 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title'};
 	let fieldOptions2 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
 	let fieldOptions3 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
-	let [firstFieldComboBox, secondFieldComboBox, lastFieldComboBox] = addTripleStringDropDown(group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
+	let [firstFieldDropDown, secondFieldDropDown, lastFieldDropDown] = addTripleStringDropDown(group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
 
 	addResetButton(group,'Reset Label settings',[
 		'max-string-length','refresh-rate','button-placeholder','label-filtered-list','divider-string','first-field','second-field',
@@ -120,19 +114,19 @@ function fillPreferencesWindow(window){
 	row.add_suffix(doubleClickLabel);
 	group.add(row);
 
-	let [leftClickComboBox, leftDoubleClickComboBox] = addDoubleStringDropDown(group,'left-click-action','left-double-click-action','Left click',buttonActions,undefined);
-	let [middleClickComboBox, middleDoubleClickComboBox] = addDoubleStringDropDown(group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,undefined,);
-	let [rightClickComboBox, rightDoubleClickComboBox] = addDoubleStringDropDown(group,'right-click-action','right-double-click-action','Right click',buttonActions,undefined);
-	let [thumbForwardComboBox, thumbDoubleForwardComboBox] = addDoubleStringDropDown(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,undefined);
-	let [thumbBackwardComboBox, thumbDoubleBackwardComboBox] = addDoubleStringDropDown(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
+	let [leftClickDropDown, leftDoubleClickDropDown] = addDoubleStringDropDown(group,'left-click-action','left-double-click-action','Left click',buttonActions,undefined);
+	let [middleClickDropDown, middleDoubleClickDropDown] = addDoubleStringDropDown(group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,undefined,);
+	let [rightClickDropDown, rightDoubleClickDropDown] = addDoubleStringDropDown(group,'right-click-action','right-double-click-action','Right click',buttonActions,undefined);
+	let [thumbForwardDropDown, thumbDoubleForwardDropDown] = addDoubleStringDropDown(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,undefined);
+	let [thumbBackwardDropDown, thumbDoubleBackwardDropDown] = addDoubleStringDropDown(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,undefined);
 
 	group = addGroup(page,'');
-	let scrollComboBox = addDropDown(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
-	scrollComboBox.set_size_request(140,-1); //match size with next button
+	let scrollDropDown = addDropDown(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined);
+	scrollDropDown.set_size_request(140,-1); //match size with next button
 
 	group = addGroup(page,'Behaviour');
-	let VolumeControlComboBox = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
-	VolumeControlComboBox.set_size_request(140,-1); //match size with previous button
+	let VolumeControlDropDown = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined);
+	VolumeControlDropDown.set_size_request(140,-1); //match size with previous button
 
 	addResetButton(group,'Reset Controls settings',[
 		'enable-double-clicks','double-click-time','left-click-action','left-double-click-action','middle-click-action','middle-double-click-action',
@@ -140,7 +134,7 @@ function fillPreferencesWindow(window){
 		'thumb-double-backward-action','volume-control-scheme']
 	);
 
-	[doubleClickTime, doubleClickLabel, leftDoubleClickComboBox, middleDoubleClickComboBox, rightDoubleClickComboBox, thumbDoubleForwardComboBox, thumbDoubleBackwardComboBox]
+	[doubleClickTime, doubleClickLabel, leftDoubleClickDropDown, middleDoubleClickDropDown, rightDoubleClickDropDown, thumbDoubleForwardDropDown, thumbDoubleBackwardDropDown]
 		.forEach(el => bindEnabled(settings, 'enable-double-clicks', el));
 }
 

--- a/prefs.js
+++ b/prefs.js
@@ -201,8 +201,8 @@ function addDropDown(group,setting,labelstring,options,labeltooltip){
 	let thisResetButton = buildDropDownResetButton([setting],[thisDropDownRow],[options])
 
 	thisDropDownRow.connect('notify::selected-item', () => {
-		let dropDownValue = Object.values(options)[thisDropDownRow.get_selected()]
-		settings.set_string(setting,dropDownValue);
+		let thisDropDownValue = Object.values(options)[thisDropDownRow.get_selected()]
+		settings.set_string(setting,thisDropDownValue);
 		let setVisible = setDropDownResetVisibility([setting],[thisDropDownRow],[options]);
 		thisResetButton.set_visible(setVisible)
 	});
@@ -219,79 +219,74 @@ function addDoubleStringDropDown(group, setting1, setting2, labelstring, options
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 135;
 
-	let dropDown1 = buildDropDown(settings, setting1, options, width);
-	let dropDown2 = buildDropDown(settings, setting2, options, width);
-	let thisResetButton = buildDropDownResetButton([setting1,setting2],[dropDown1,dropDown2],[options,options])
+	let thisDropDown1 = buildDropDown(settings, setting1, options, width);
+	let thisDropDown2 = buildDropDown(settings, setting2, options, width);
+	let thisResetButton = buildDropDownResetButton([setting1,setting2],[thisDropDown1,thisDropDown2],[options,options])
 
-	dropDown1.connect('notify::selected-item', () => {
-		let dropDownValue = Object.values(options)[dropDown1.get_selected()];
-		settings.set_string(setting1,dropDownValue);
-		let setVisible = setDropDownResetVisibility([setting1,setting2],[dropDown1,dropDown2],[options,options]);
+	thisDropDown1.connect('notify::selected-item', () => {
+		let thisDropDownValue = Object.values(options)[thisDropDown1.get_selected()];
+		settings.set_string(setting1,thisDropDownValue);
+		let setVisible = setDropDownResetVisibility([setting1,setting2],[thisDropDown1,thisDropDown2],[options,options]);
 		thisResetButton.set_visible(setVisible)
 	});
 
-	dropDown2.connect('notify::selected-item', () => {
-		let dropDownValue = Object.values(options)[dropDown2.get_selected()];
-		settings.set_string(setting2,dropDownValue);
-		let setVisible = setDropDownResetVisibility([setting1,setting2],[dropDown1,dropDown2],[options,options]);
+	thisDropDown2.connect('notify::selected-item', () => {
+		let thisDropDownValue = Object.values(options)[thisDropDown2.get_selected()];
+		settings.set_string(setting2,thisDropDownValue);
+		let setVisible = setDropDownResetVisibility([setting1,setting2],[thisDropDown1,thisDropDown2],[options,options]);
 		thisResetButton.set_visible(setVisible)
-		// //hide reset button if both values match default
-		// if (dropDownValue1 == settings.get_default_value(setting1).print(true).replaceAll('\'', '') && dropDownValue2 == settings.get_default_value(setting2).print(true).replaceAll('\'', ''))
-		// 	thisResetButton.set_visible(false);
-		// else
-		// 	thisResetButton.set_visible(true);
 	});
 
 	row.add_suffix(thisResetButton);
-	row.add_suffix(dropDown1);
-	row.add_suffix(dropDown2);
+	row.add_suffix(thisDropDown1);
+	row.add_suffix(thisDropDown2);
 
 	group.add(row)
 
-	return [dropDown1, dropDown2]
+	return [thisDropDown1, thisDropDown2]
 }
 
 function addTripleStringDropDown(group, setting1, setting2, setting3, labelstring, options1, options2, options3, labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 	let width = 81;
 
-	let dropDown1 = buildDropDown(settings, setting1, options1,width);
-	let dropDown2 = buildDropDown(settings, setting2, options2,width);
-	let dropDown3 = buildDropDown(settings, setting3, options3,width);
-	let thisResetButton = buildDropDownResetButton([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3])
+	let thisDropDown1 = buildDropDown(settings, setting1, options1,width);
+	let thisDropDown2 = buildDropDown(settings, setting2, options2,width);
+	let thisDropDown3 = buildDropDown(settings, setting3, options3,width);
+	let thisResetButton = buildDropDownResetButton([setting1,setting2,setting3],[thisDropDown1,thisDropDown2,thisDropDown3],[options1,options2,options3])
 
-	dropDown1.connect('notify::selected-item', () => {
-		settings.set_string(setting1,Object.values(options1)[dropDown1.get_selected()]);
-		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3]);
+	thisDropDown1.connect('notify::selected-item', () => {
+		settings.set_string(setting1,Object.values(options1)[thisDropDown1.get_selected()]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[thisDropDown1,thisDropDown2,thisDropDown3],[options1,options2,options3]);
 		thisResetButton.set_visible(setVisible)
 	});
 
-	dropDown2.connect('notify::selected-item', () => {
-		settings.set_string(setting2,Object.values(options2)[dropDown2.get_selected()]);
-		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3]);
+	thisDropDown2.connect('notify::selected-item', () => {
+		settings.set_string(setting2,Object.values(options2)[thisDropDown2.get_selected()]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[thisDropDown1,thisDropDown2,thisDropDown3],[options1,options2,options3]);
 		thisResetButton.set_visible(setVisible)
 	});
 
-	dropDown3.connect('notify::selected-item', () => {
-		settings.set_string(setting3,Object.values(options3)[dropDown3.get_selected()]);
-		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[dropDown1,dropDown2,dropDown3],[options1,options2,options3]);
+	thisDropDown3.connect('notify::selected-item', () => {
+		settings.set_string(setting3,Object.values(options3)[thisDropDown3.get_selected()]);
+		let setVisible = setDropDownResetVisibility([setting1,setting2,setting3],[thisDropDown1,thisDropDown2,thisDropDown3],[options1,options2,options3]);
 		thisResetButton.set_visible(setVisible)
 	});
 
 	row.add_suffix(thisResetButton);
-	row.add_suffix(dropDown1);
-	row.add_suffix(dropDown2);
-	row.add_suffix(dropDown3);
+	row.add_suffix(thisDropDown1);
+	row.add_suffix(thisDropDown2);
+	row.add_suffix(thisDropDown3);
 
 	group.add(row)
-	return [dropDown1, dropDown2, dropDown3]
+	return [thisDropDown1, thisDropDown2, thisDropDown3]
 }
 
-function setDropDownResetVisibility(settingsList,dropDownList,optionsList){ //show reset button if any of the values is different from default
+function setDropDownResetVisibility(settingsList,thisDropDownList,optionsList){ //show reset button if any of the values is different from default
 	let setVisible = false;
-	for (let i = 0; i < dropDownList.length; i++) {
-		let dropDownValue = Object.values(optionsList[i])[dropDownList[i].get_selected()];
-		if (dropDownValue != settings.get_default_value(settingsList[i]).print(true).replaceAll('\'', ''))
+	for (let i = 0; i < thisDropDownList.length; i++) {
+		let thisDropDownValue = Object.values(optionsList[i])[thisDropDownList[i].get_selected()];
+		if (thisDropDownValue != settings.get_default_value(settingsList[i]).print(true).replaceAll('\'', ''))
 			setVisible = true;
 	}
 	return setVisible;

--- a/prefs.js
+++ b/prefs.js
@@ -195,8 +195,7 @@ function fillPreferencesWindow(window){
 		.forEach(el => bindEnabled(settings, 'enable-double-clicks', el));
 }
 
-//functions starting with 'add' adds a widget to the selected grid(or widget)
-//functions starting with 'build' creates the "generic" widget and returns it
+// Adwaita "design" and "structure" functions
 
 function addPreferencesPage(window,name,icon){
 	let thisPage = new Adw.PreferencesPage({
@@ -214,59 +213,7 @@ function addGroup(page,title){
 	return thisGroup;
 }
 
-function buildActionRow(labelstring,labeltooltip){
-	let row = new Adw.ActionRow({ title: labelstring });
-	if ( labeltooltip ){
-		if (labeltooltip.length>70){ //could make every tooltip a button if preferred
-			let thisInfoButton = buildInfoButton(labeltooltip);
-			row.add_suffix(thisInfoButton);
-		}
-		else
-			row.subtitle = labeltooltip;
-	}
-
-	return row;
-}
-
-function buildInfoButton(labeltooltip){
-	let thisInfoButton = new Gtk.MenuButton({
-		valign: Gtk.Align.CENTER,
-		icon_name: 'info-symbolic',
-		visible: true
-	});
-	thisInfoButton.add_css_class('flat');
-	// thisInfoButton.add_css_class('circular');
-	let thisPopover = new Gtk.Popover();
-	let thisLabel = new Gtk.Label({
-		label: labeltooltip
-	});
-	thisPopover.set_child(thisLabel);
-	thisInfoButton.set_popover(thisPopover);
-
-	return thisInfoButton;
-}
-
-function buildResetButton(setting){
-	let thisResetButton = new Gtk.Button({
-		valign: Gtk.Align.CENTER,
-		icon_name: 'edit-clear-symbolic-rtl',
-		visible: false
-	});
-
-	//hide if default setting
-	if (settings.get_user_value(setting) != null)
-		thisResetButton.set_visible(true)
-
-	thisResetButton.add_css_class('flat');
-	thisResetButton.set_tooltip_text('Reset to Default');
-
-	thisResetButton.connect('clicked',() => {
-		settings.reset(setting);
-		thisResetButton.set_visible(false)
-	});
-
-	return thisResetButton;
-}
+// Adwaita 'Row' functions, they add a row to the target group with the widget(s) specified
 
 function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
@@ -292,48 +239,6 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 
 	group.add(row);
 	return row;
-}
-
-function buildDropDown(settings,setting,options,width){
-
-	let thisDropDown = new Gtk.DropDown({
-		model: Gtk.StringList.new(Object.keys(options)),
-		selected: Object.values(options).indexOf(settings.get_string(setting)),
-		valign: Gtk.Align.CENTER,
-		halign: Gtk.Align.END
-	});
-
-	if (width)
-		thisDropDown.set_size_request(width,-1);
-
-	return thisDropDown;
-}
-
-function buildDropDownResetButton(setting,combobox,options){
-	let thisResetButton = new Gtk.Button({
-		valign: Gtk.Align.CENTER,
-		icon_name: 'edit-clear-symbolic-rtl',
-		visible: false
-	});
-
-	//hide if default setting
-	setting.forEach((item) => {
-		if (settings.get_user_value(item) != null && settings.get_user_value(item) != settings.get_default_value(item))
-			thisResetButton.set_visible(true);
-	})
-
-	thisResetButton.add_css_class('flat');
-	thisResetButton.set_tooltip_text('Reset to Default');
-
-	thisResetButton.connect('clicked',() => {
-		 for (let i = 0; i < setting.length; i++) {
-			settings.reset(setting[i]);
-			combobox[i].set_selected(Object.values(options[i]).indexOf(settings.get_string(setting[i])));
-		}
-		thisResetButton.set_visible(false);
-	});
-
-	return thisResetButton;
 }
 
 function addDropDown(group,setting,labelstring,options,labeltooltip){
@@ -489,6 +394,116 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 	return thisEntry;
 }
 
+function addButton(group,labelstring,callback){
+	button = new Gtk.Button({
+		label: labelstring,
+		margin_top: 30,
+		visible: true
+	});
+	button.connect('clicked',callback);
+	group.add(button);
+
+	return button
+}
+
+// 'build' functions, they build "generic" widgets for the specified type and returns it
+
+function buildActionRow(labelstring,labeltooltip){
+	let row = new Adw.ActionRow({ title: labelstring });
+	if ( labeltooltip ){
+		if (labeltooltip.length>70){ //could make every tooltip a button if preferred
+			let thisInfoButton = buildInfoButton(labeltooltip);
+			row.add_suffix(thisInfoButton);
+		}
+		else
+			row.subtitle = labeltooltip;
+	}
+
+	return row;
+}
+
+function buildInfoButton(labeltooltip){
+	let thisInfoButton = new Gtk.MenuButton({
+		valign: Gtk.Align.CENTER,
+		icon_name: 'info-symbolic',
+		visible: true
+	});
+	thisInfoButton.add_css_class('flat');
+	// thisInfoButton.add_css_class('circular');
+	let thisPopover = new Gtk.Popover();
+	let thisLabel = new Gtk.Label({
+		label: labeltooltip
+	});
+	thisPopover.set_child(thisLabel);
+	thisInfoButton.set_popover(thisPopover);
+
+	return thisInfoButton;
+}
+
+function buildResetButton(setting){
+	let thisResetButton = new Gtk.Button({
+		valign: Gtk.Align.CENTER,
+		icon_name: 'edit-clear-symbolic-rtl',
+		visible: false
+	});
+
+	//hide if default setting
+	if (settings.get_user_value(setting) != null)
+		thisResetButton.set_visible(true)
+
+	thisResetButton.add_css_class('flat');
+	thisResetButton.set_tooltip_text('Reset to Default');
+
+	thisResetButton.connect('clicked',() => {
+		settings.reset(setting);
+		thisResetButton.set_visible(false)
+	});
+
+	return thisResetButton;
+}
+
+function buildDropDown(settings,setting,options,width){
+
+	let thisDropDown = new Gtk.DropDown({
+		model: Gtk.StringList.new(Object.keys(options)),
+		selected: Object.values(options).indexOf(settings.get_string(setting)),
+		valign: Gtk.Align.CENTER,
+		halign: Gtk.Align.END
+	});
+
+	if (width)
+		thisDropDown.set_size_request(width,-1);
+
+	return thisDropDown;
+}
+
+function buildDropDownResetButton(setting,combobox,options){
+	let thisResetButton = new Gtk.Button({
+		valign: Gtk.Align.CENTER,
+		icon_name: 'edit-clear-symbolic-rtl',
+		visible: false
+	});
+
+	//hide if default setting
+	setting.forEach((item) => {
+		if (settings.get_user_value(item) != null && settings.get_user_value(item) != settings.get_default_value(item))
+			thisResetButton.set_visible(true);
+	})
+
+	thisResetButton.add_css_class('flat');
+	thisResetButton.set_tooltip_text('Reset to Default');
+
+	thisResetButton.connect('clicked',() => {
+		 for (let i = 0; i < setting.length; i++) {
+			settings.reset(setting[i]);
+			combobox[i].set_selected(Object.values(options[i]).indexOf(settings.get_string(setting[i])));
+		}
+		thisResetButton.set_visible(false);
+	});
+
+	return thisResetButton;
+}
+
 function buildStringDropDown(settings,setting,options,width){
 	let thisComboBox = new Gtk.ComboBoxText({//consider using Adw.ComboRow
 		valign: Gtk.Align.CENTER,
@@ -509,17 +524,13 @@ function buildStringDropDown(settings,setting,options,width){
 	return thisComboBox
 }
 
-function addButton(group,labelstring,callback){
-	button = new Gtk.Button({
-		label: labelstring,
-		margin_top: 30,
-		visible: true
-	});
-	button.connect('clicked',callback);
-	group.add(button);
+// helper functions
 
-	return button
+function bindEnabled(settings, setting, element) {
+	settings.bind(setting, element, 'visible', Gio.SettingsBindFlags.GET);
 }
+
+// specific job/usage functions
 
 function playersToString(){
 	const dBusInterface = `
@@ -554,9 +565,5 @@ function playersToString(){
 	});
 
 	return newList.toString()
-}
-
-function bindEnabled(settings, setting, element) {
-	settings.bind(setting, element, 'visible', Gio.SettingsBindFlags.GET);
 }
 


### PR DESCRIPTION
See first pass implementation of reset buttons. Note that I had to adjust some of the supporting text to make everything fit as it's getting relatively busy.

The buttons work for all widgets with the exception of the ComboBox which don't update to the default values. To be clear, it does reset gsettings but I can't figure out how to make the button also reset the comboBox value in a generic way which would work in the `buildResetButton()`. Would you mind having a look at it?