### PR TITLE
Code cleanup for future compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,7 +14,7 @@ const { buildLabel } = CurrentExtension.imports.label;
 let indicator = null;
 
 function enable(){
-	indicator = new MprisLabel();
+	indicator = new MprisLabel(ExtensionUtils.getSettings());
 }
 
 function disable(){
@@ -26,10 +26,10 @@ function disable(){
 var MprisLabel = GObject.registerClass(
 	{ GTypeName: 'MprisLabel' },
 class MprisLabel extends PanelMenu.Button {
-	_init(){
+	_init(settings){
 		super._init(0.0,'Mpris Label',false);
 
-		this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
+		this.settings = settings;
 
 		const EXTENSION_INDEX = this.settings.get_int('extension-index');
 		const EXTENSION_PLACE = this.settings.get_string('extension-place');

--- a/extension.js
+++ b/extension.js
@@ -47,7 +47,7 @@ class MprisLabel extends PanelMenu.Button {
 		});
 		this.box.add_child(this.label);
 
-		this.players = new Players();
+		this.players = new Players(this.settings);
 
 		this.connect('button-press-event',(_a, event) => this._onClick(event));
 		this.connect('scroll-event', (_a, event) => this._onScroll(event));

--- a/extension.js
+++ b/extension.js
@@ -14,15 +14,13 @@ const { buildLabel } = CurrentExtension.imports.label;
 let indicator = null;
 
 function enable(){
-	this.settings = ExtensionUtils.getSettings()
-	indicator = new MprisLabel(this.settings);
+	indicator = new MprisLabel(ExtensionUtils.getSettings());
 }
 
 function disable(){
 	indicator._disable();
 	indicator.destroy();
 	indicator = null;
-	this.settings = null;
 }
 
 var MprisLabel = GObject.registerClass(

--- a/extension.js
+++ b/extension.js
@@ -14,13 +14,15 @@ const { buildLabel } = CurrentExtension.imports.label;
 let indicator = null;
 
 function enable(){
-	indicator = new MprisLabel(ExtensionUtils.getSettings());
+	this.settings = ExtensionUtils.getSettings()
+	indicator = new MprisLabel(this.settings);
 }
 
 function disable(){
 	indicator._disable();
 	indicator.destroy();
 	indicator = null;
+	this.settings = null;
 }
 
 var MprisLabel = GObject.registerClass(

--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;

--- a/extension.js
+++ b/extension.js
@@ -340,7 +340,7 @@ class MprisLabel extends PanelMenu.Button {
 	//player selection submenu:
 		this.players.list.forEach(player => {
 			let settingsMenuItem = new PopupMenu.PopupMenuItem(player.identity);
-
+			settingsMenuItem.setOrnament(PopupMenu.Ornament.NONE); //to force item horizontal alignment
 			if (AUTO_SWITCH_TO_MOST_RECENT){
 				if(!this.unfocusColor)
 					this._determineColors();
@@ -375,6 +375,7 @@ class MprisLabel extends PanelMenu.Button {
 	//automode entry:
 		if (this.players.list.length > 0){
 			let settingsMenuItem = new PopupMenu.PopupMenuItem('Switch Automatically');
+			settingsMenuItem.setOrnament(PopupMenu.Ornament.NONE); //to force item horizontal alignment
 			if (AUTO_SWITCH_TO_MOST_RECENT) {
 				settingsMenuItem.setOrnament(PopupMenu.Ornament.CHECK);
 				settingsMenuItem.label.set_style('font-weight:bold');

--- a/extension.js
+++ b/extension.js
@@ -481,7 +481,7 @@ class MprisLabel extends PanelMenu.Button {
 			if(this.player == null || undefined)
 				this.label.set_text("")
 			else
-				this.label.set_text(buildLabel(this.players));
+				this.label.set_text(buildLabel(this.players,this.settings));
 		}
 		catch(err){
 			log("Mpris Label: " + err);

--- a/label.js
+++ b/label.js
@@ -1,15 +1,15 @@
 'use strict';
 
 var buildLabel = function buildLabel(players,settings){
-	let MAX_STRING_LENGTH = settings.get_int('max-string-length');
-	let BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
-	let LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
-	let DIVIDER_STRING = settings.get_string('divider-string');
-	let REMOVE_TEXT_WHEN_PAUSED = settings.get_boolean('remove-text-when-paused');
-	let REMOVE_TEXT_PAUSED_DELAY = settings.get_int('remove-text-paused-delay');
-	let FIRST_FIELD = settings.get_string('first-field');
-	let SECOND_FIELD = settings.get_string('second-field');
-	let LAST_FIELD = settings.get_string('last-field');
+	const MAX_STRING_LENGTH = settings.get_int('max-string-length');
+	const BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
+	const LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
+	const DIVIDER_STRING = settings.get_string('divider-string');
+	const REMOVE_TEXT_WHEN_PAUSED = settings.get_boolean('remove-text-when-paused');
+	const REMOVE_TEXT_PAUSED_DELAY = settings.get_int('remove-text-paused-delay');
+	const FIRST_FIELD = settings.get_string('first-field');
+	const SECOND_FIELD = settings.get_string('second-field');
+	const LAST_FIELD = settings.get_string('last-field');
 
 	// the placeholder string is a hint for the user to switch players
 	// it should appear if labelstring is empty and there's another player playing

--- a/label.js
+++ b/label.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var buildLabel = function buildLabel(players,settings){
 	const MAX_STRING_LENGTH = settings.get_int('max-string-length');
 	const BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');

--- a/label.js
+++ b/label.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
 

--- a/label.js
+++ b/label.js
@@ -1,23 +1,15 @@
 'use strict';
 
-let MAX_STRING_LENGTH,BUTTON_PLACEHOLDER,LABEL_FILTERED_LIST,
-	DIVIDER_STRING,REMOVE_TEXT_WHEN_PAUSED,
-	REMOVE_TEXT_PAUSED_DELAY,FIRST_FIELD,SECOND_FIELD,LAST_FIELD;
-
-function getSettings(settings){
-	MAX_STRING_LENGTH = settings.get_int('max-string-length');
-	BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
-	LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
-	DIVIDER_STRING = settings.get_string('divider-string');
-	REMOVE_TEXT_WHEN_PAUSED = settings.get_boolean('remove-text-when-paused');
-	REMOVE_TEXT_PAUSED_DELAY = settings.get_int('remove-text-paused-delay');
-	FIRST_FIELD = settings.get_string('first-field');
-	SECOND_FIELD = settings.get_string('second-field');
-	LAST_FIELD = settings.get_string('last-field');
-}
-
 var buildLabel = function buildLabel(players,settings){
-	getSettings(settings);
+	let MAX_STRING_LENGTH = settings.get_int('max-string-length');
+	let BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
+	let LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
+	let DIVIDER_STRING = settings.get_string('divider-string');
+	let REMOVE_TEXT_WHEN_PAUSED = settings.get_boolean('remove-text-when-paused');
+	let REMOVE_TEXT_PAUSED_DELAY = settings.get_int('remove-text-paused-delay');
+	let FIRST_FIELD = settings.get_string('first-field');
+	let SECOND_FIELD = settings.get_string('second-field');
+	let LAST_FIELD = settings.get_string('last-field');
 
 	// the placeholder string is a hint for the user to switch players
 	// it should appear if labelstring is empty and there's another player playing
@@ -44,8 +36,9 @@ var buildLabel = function buildLabel(players,settings){
 
 	let labelstring = "";
 	fields.forEach(field => {
-		let fieldString = players.selected.stringFromMetadata(field,metadata); //"extract" the string from metadata
-		fieldString = parseMetadataField(fieldString,settings); //check, filter, customize and add divider to the extracted string
+		let labelSettings = [LABEL_FILTERED_LIST,MAX_STRING_LENGTH,DIVIDER_STRING]
+		let fieldString = players.selected.stringFromMetadata(field,metadata,labelSettings); //"extract" the string from metadata
+		fieldString = parseMetadataField(fieldString,settings,labelSettings); //check, filter, customize and add divider to the extracted string
 		labelstring += fieldString; //add it to the string to be displayed
 	});
 
@@ -57,7 +50,7 @@ var buildLabel = function buildLabel(players,settings){
 	return labelstring
 }
 
-function parseMetadataField(data,settings) {
+function parseMetadataField(data,settings,[LABEL_FILTERED_LIST,MAX_STRING_LENGTH,DIVIDER_STRING]) {
 	if (data == undefined || data.length == 0)
 		return ""
 

--- a/label.js
+++ b/label.js
@@ -1,14 +1,10 @@
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const CurrentExtension = ExtensionUtils.getCurrentExtension();
-
 let MAX_STRING_LENGTH,BUTTON_PLACEHOLDER,LABEL_FILTERED_LIST,
 	DIVIDER_STRING,REMOVE_TEXT_WHEN_PAUSED,
 	REMOVE_TEXT_PAUSED_DELAY,FIRST_FIELD,SECOND_FIELD,LAST_FIELD;
 
-function getSettings(){
-	const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
+function getSettings(settings){
 	MAX_STRING_LENGTH = settings.get_int('max-string-length');
 	BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
 	LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
@@ -20,8 +16,8 @@ function getSettings(){
 	LAST_FIELD = settings.get_string('last-field');
 }
 
-var buildLabel = function buildLabel(players){
-	getSettings();
+var buildLabel = function buildLabel(players,settings){
+	getSettings(settings);
 
 	// the placeholder string is a hint for the user to switch players
 	// it should appear if labelstring is empty and there's another player playing
@@ -49,7 +45,7 @@ var buildLabel = function buildLabel(players){
 	let labelstring = "";
 	fields.forEach(field => {
 		let fieldString = players.selected.stringFromMetadata(field,metadata); //"extract" the string from metadata
-		fieldString = parseMetadataField(fieldString); //check, filter, customize and add divider to the extracted string
+		fieldString = parseMetadataField(fieldString,settings); //check, filter, customize and add divider to the extracted string
 		labelstring += fieldString; //add it to the string to be displayed
 	});
 
@@ -61,7 +57,7 @@ var buildLabel = function buildLabel(players){
 	return labelstring
 }
 
-function parseMetadataField(data) {
+function parseMetadataField(data,settings) {
 	if (data == undefined || data.length == 0)
 		return ""
 
@@ -77,7 +73,6 @@ function parseMetadataField(data) {
 		const sanitizedInput = LABEL_FILTERED_LIST.replace(CtrlCharactersRegex,"")
 
 		if(sanitizedInput != LABEL_FILTERED_LIST){
-			const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 			settings.set_string('label-filtered-list',sanitizedInput);
 		}
 

--- a/label.js
+++ b/label.js
@@ -5,13 +5,11 @@ const CurrentExtension = ExtensionUtils.getCurrentExtension();
 
 let MAX_STRING_LENGTH,BUTTON_PLACEHOLDER,LABEL_FILTERED_LIST,
 	DIVIDER_STRING,REMOVE_TEXT_WHEN_PAUSED,
-	REMOVE_TEXT_PAUSED_DELAY,FIRST_FIELD,SECOND_FIELD,LAST_FIELD
-	MAX_STRING_LENGTH,DIVIDER_STRING;
+	REMOVE_TEXT_PAUSED_DELAY,FIRST_FIELD,SECOND_FIELD,LAST_FIELD;
 
 function getSettings(){
 	const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 	MAX_STRING_LENGTH = settings.get_int('max-string-length');
-	REFRESH_RATE = settings.get_int('refresh-rate');
 	BUTTON_PLACEHOLDER = settings.get_string('button-placeholder');
 	LABEL_FILTERED_LIST = settings.get_string('label-filtered-list');
 	DIVIDER_STRING = settings.get_string('divider-string');

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,6 @@
     "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
     "version": 23,
     "shell-version": [ "43", "44" ],
-    "url": "https://github.com/Moon-0xff/gnome-mpris-label"
+    "url": "https://github.com/Moon-0xff/gnome-mpris-label",
+    "settings-schema": "org.gnome.shell.extensions.mpris-label"
 }

--- a/players.js
+++ b/players.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
+const {Gio,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();
 

--- a/players.js
+++ b/players.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {Gio,Shell,St} = imports.gi;
 
 const mprisInterface = `

--- a/players.js
+++ b/players.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const {Gio,Shell,St} = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const CurrentExtension = ExtensionUtils.getCurrentExtension();
 
 const mprisInterface = `
 <node>
@@ -44,12 +42,12 @@ const dBusInterface = `
 </node>`
 
 var Players = class Players {
-	constructor(){
+	constructor(settings){
 		this.list = [];
 		this.activePlayers= [];
 		const dBusProxyWrapper = Gio.DBusProxy.makeProxyWrapper(dBusInterface);
 		this.dBusProxy = dBusProxyWrapper(Gio.DBus.session,"org.freedesktop.DBus","/org/freedesktop/DBus",this._initList.bind(this));
-		this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
+		this.settings = settings;
 	}
 	pick(){
 		const REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused');

--- a/players.js
+++ b/players.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {Clutter,Gio,GLib,GObject,Shell,St} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const CurrentExtension = ExtensionUtils.getCurrentExtension();

--- a/players.js
+++ b/players.js
@@ -50,7 +50,6 @@ var Players = class Players {
 		this.settings = settings;
 	}
 	pick(){
-		const REMOVE_TEXT_WHEN_PAUSED = this.settings.get_boolean('remove-text-when-paused');
 		const AUTO_SWITCH_TO_MOST_RECENT = this.settings.get_boolean('auto-switch-to-most-recent');
 
 		if(this.list.length == 0){

--- a/players.js
+++ b/players.js
@@ -198,7 +198,7 @@ class Player {
 		if ( matchedEntries.length > 0 )
 			this.desktopApp = this._matchRunningApps(matchedEntries)
 
-		this.icon = this.getIcon(this.desktopApp);
+		this.icon = this.getIcon();
 	}
 	_matchRunningApps(matchedEntries){
 		const activeApps = Shell.AppSystem.get_default().get_running();

--- a/prefs.js
+++ b/prefs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {Adw,Gio,Gtk} = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;

--- a/prefs.js
+++ b/prefs.js
@@ -99,13 +99,13 @@ function fillPreferencesWindow(window){
 
 	group = addGroup(page,'Mouse bindings');
 
-	row = new Adw.ActionRow({ title: ''});
+	let row = new Adw.ActionRow({ title: ''});
 	let singleClickLabel = new Gtk.Label({ //not sure how to underline or reduce height
 		label: 'Single click',
 		width_chars: 17
 	});
 	row.add_suffix(singleClickLabel);
-	doubleClickLabel = new Gtk.Label({
+	let doubleClickLabel = new Gtk.Label({
 		label: 'Double click',
 		width_chars: 17
 	});
@@ -480,7 +480,7 @@ function playersToString(){
 
 	let newList = [];
 	list.forEach(element => {
-		entryProxy = entryWrapper(Gio.DBus.session,element,"/org/mpris/MediaPlayer2");
+		let entryProxy = entryWrapper(Gio.DBus.session,element,"/org/mpris/MediaPlayer2");
 		let identity = entryProxy.Identity;
 		newList.push(identity);
 	});

--- a/prefs.js
+++ b/prefs.js
@@ -4,34 +4,34 @@ const {Adw,Gio,Gtk} = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Config = imports.misc.config;
-const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 
 function init(){}
 
 function fillPreferencesWindow(window){
+	let settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.mpris-label');
 	window.default_height = 950;
 
 //panel page:
 	let page = addPreferencesPage(window,'Panel','computer-symbolic');
 
 	let group = addGroup(page,'Icon');
-	let [showIconDropDown] = addDropDown(group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
-	addSpinButton(group, 'icon-padding', 'Icon padding', 0, 50, undefined);
-	addSwitch(group, 'symbolic-source-icon', 'Use symbolic source icon', "Uses an icon that follows the shell's color scheme");
-	addSwitch(group,'use-album','Use album art as icon when available',undefined);
-	addSpinButton(group,'album-size','Album art scaling (in %)',20,250,undefined);
+	let [showIconDropDown] = addDropDown(settings,group,'show-icon','Show source icon',{'off':'','left':'left','right':'right'},undefined);
+	addSpinButton(settings,group,'icon-padding', 'Icon padding', 0, 50, undefined);
+	addSwitch(settings,group,'symbolic-source-icon', 'Use symbolic source icon', "Uses an icon that follows the shell's color scheme");
+	addSwitch(settings,group,'use-album','Use album art as icon when available',undefined);
+	addSpinButton(settings,group,'album-size','Album art scaling (in %)',20,250,undefined);
 
 	group = addGroup(page,'Position');
-	let [extensionPlaceDropDown] = addDropDown(group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
-	addSpinButton(group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
-	addSpinButton(group,'left-padding','Left padding',0,500,undefined);
-	addSpinButton(group,'right-padding','Right padding',0,500,undefined);
+	let [extensionPlaceDropDown] = addDropDown(settings,group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
+	addSpinButton(settings,group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
+	addSpinButton(settings,group,'left-padding','Left padding',0,500,undefined);
+	addSpinButton(settings,group,'right-padding','Right padding',0,500,undefined);
 
 	group = addGroup(page,'Wrong index at loadup mitigations');
-	addSpinButton(group,'reposition-delay','Panel reposition at startup (delay in seconds)',0,300,"Increase this value if extension index isn't respected at startup");
-	addSwitch(group,'reposition-on-button-press','Update panel position on every button press',undefined);
+	addSpinButton(settings,group,'reposition-delay','Panel reposition at startup (delay in seconds)',0,300,"Increase this value if extension index isn't respected at startup");
+	addSwitch(settings,group,'reposition-on-button-press','Update panel position on every button press',undefined);
 
-	addResetButton(group,'Reset Panel settings',[
+	addResetButton(settings,group,'Reset Panel settings',[
 		'show-icon','left-padding','right-padding','extension-index','extension-place','reposition-delay','reposition-on-button-press','use-album',
 		'album-size','symbolic-source-icon','icon-padding'],
 		[showIconDropDown,extensionPlaceDropDown]
@@ -41,23 +41,23 @@ function fillPreferencesWindow(window){
 	page = addPreferencesPage(window,'Label','document-edit-symbolic');
 
 	group = addGroup(page,'Behaviour');
-	addSwitch(group,'auto-switch-to-most-recent','Switch to the most recent source automatically',"This option can be annoying without the use of filter lists");
-	addSwitch(group,'remove-text-when-paused','Hide when paused',undefined);
-	addSpinButton(group,'remove-text-paused-delay','Hide when paused delay (seconds)',0,9999,undefined);
-	addSpinButton(group,'refresh-rate','Refresh rate (milliseconds)',30,3000,undefined);
-	addEntry(group,'label-filtered-list','Filter segments containing',"Separate entries with commas, special characters will be removed\n\nThe targeted segments are defined in code as:\n\t\A substring enclosed by parentheses, square brackets,\n\t or between the end of the string and a hyphen");
+	addSwitch(settings,group,'auto-switch-to-most-recent','Switch to the most recent source automatically',"This option can be annoying without the use of filter lists");
+	addSwitch(settings,group,'remove-text-when-paused','Hide when paused',undefined);
+	addSpinButton(settings,group,'remove-text-paused-delay','Hide when paused delay (seconds)',0,9999,undefined);
+	addSpinButton(settings,group,'refresh-rate','Refresh rate (milliseconds)',30,3000,undefined);
+	addEntry(settings,group,'label-filtered-list','Filter segments containing',"Separate entries with commas, special characters will be removed\n\nThe targeted segments are defined in code as:\n\t\A substring enclosed by parentheses, square brackets,\n\t or between the end of the string and a hyphen");
 
 	group = addGroup(page,'Appearance');
-	addSpinButton(group,'max-string-length','Max string length (each field)',1,150,undefined);
-	addEntry(group,'button-placeholder','Button placeholder',"The button placeholder is a hint for the user and can be left empty.\n\nIt appears when the label is empty and another available source is active");
-	addEntry(group,'divider-string','Divider string (you can use spaces)',undefined);
+	addSpinButton(settings,group,'max-string-length','Max string length (each field)',1,150,undefined);
+	addEntry(settings,group,'button-placeholder','Button placeholder',"The button placeholder is a hint for the user and can be left empty.\n\nIt appears when the label is empty and another available source is active");
+	addEntry(settings,group,'divider-string','Divider string (you can use spaces)',undefined);
 
 	let fieldOptions1 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title'};
 	let fieldOptions2 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
 	let fieldOptions3 = {'artist':'xesam:artist','album':'xesam:album','title':'xesam:title','none':''};
-	let [firstFieldDropDown, secondFieldDropDown, lastFieldDropDown] = addTripleDropDown(group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
+	let [firstFieldDropDown, secondFieldDropDown, lastFieldDropDown] = addTripleDropDown(settings,group,'first-field','second-field','last-field','Visible fields and order',fieldOptions1,fieldOptions2,fieldOptions3,undefined);
 
-	addResetButton(group,'Reset Label settings',[
+	addResetButton(settings,group,'Reset Label settings',[
 		'max-string-length','refresh-rate','button-placeholder','label-filtered-list','divider-string','first-field','second-field',
 		'last-field','remove-text-when-paused','remove-text-paused-delay','auto-switch-to-most-recent'],[firstFieldDropDown, secondFieldDropDown, lastFieldDropDown]
 	);
@@ -66,7 +66,7 @@ function fillPreferencesWindow(window){
 	page = addPreferencesPage(window,'Filters','dialog-error-symbolic');
 
 	group = addGroup(page,'List of available MPRIS Sources');
-	let sourcesListEntry = addWideEntry(group,undefined,'',"Press the button below to update");
+	let sourcesListEntry = addWideEntry(settings,group,undefined,'',"Press the button below to update");
 	sourcesListEntry.set_text(playersToString());
 	sourcesListEntry.set_editable(false);
 
@@ -76,12 +76,12 @@ function fillPreferencesWindow(window){
 	updateButton.set_margin_top(10);
 
 	group = addGroup(page,'Filters for MPRIS sources');
-	addEntry(group,'mpris-sources-blacklist','Ignore list','Separate entries with commas');
-	addEntry(group,'mpris-sources-whitelist','Allow list','Separate entries with commas');
-	addSwitch(group,'use-whitelisted-sources-only','Ignore all sources except allowed ones',"This option is ignored if the allow list is empty");
-	addEntry(group,'album-blacklist','Players excluded from using album art','Separate entries with commas');
+	addEntry(settings,group,'mpris-sources-blacklist','Ignore list','Separate entries with commas');
+	addEntry(settings,group,'mpris-sources-whitelist','Allow list','Separate entries with commas');
+	addSwitch(settings,group,'use-whitelisted-sources-only','Ignore all sources except allowed ones',"This option is ignored if the allow list is empty");
+	addEntry(settings,group,'album-blacklist','Players excluded from using album art','Separate entries with commas');
 
-	addResetButton(group,'Reset Filters settings',[
+	addResetButton(settings,group,'Reset Filters settings',[
 		'mpris-sources-blacklist','mpris-sources-whitelist','use-whitelisted-sources-only','album-blacklist']
 	);
 
@@ -94,8 +94,8 @@ function fillPreferencesWindow(window){
 	};
 
 	group = addGroup(page,'Double Click');
-	addSwitch(group, 'enable-double-clicks', 'Enable double clicks', undefined);
-	let doubleClickTime = addSpinButton(group, 'double-click-time', 'Double click time (milliseconds)', 1, 1000, undefined);
+	addSwitch(settings,group, 'enable-double-clicks', 'Enable double clicks', undefined);
+	let doubleClickTime = addSpinButton(settings,group, 'double-click-time', 'Double click time (milliseconds)', 1, 1000, undefined);
 
 	group = addGroup(page,'Mouse bindings');
 
@@ -112,19 +112,19 @@ function fillPreferencesWindow(window){
 	row.add_suffix(doubleClickLabel);
 	group.add(row);
 
-	let [leftClickDropDown, leftDoubleClickDropDown] = addDoubleDropDown(group,'left-click-action','left-double-click-action','Left click',buttonActions,buttonActions,undefined);
-	let [middleClickDropDown, middleDoubleClickDropDown] = addDoubleDropDown(group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,buttonActions,undefined);
-	let [rightClickDropDown, rightDoubleClickDropDown] = addDoubleDropDown(group,'right-click-action','right-double-click-action','Right click',buttonActions,buttonActions,undefined);
-	let [thumbForwardDropDown, thumbDoubleForwardDropDown] = addDoubleDropDown(group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,buttonActions,undefined);
-	let [thumbBackwardDropDown, thumbDoubleBackwardDropDown] = addDoubleDropDown(group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,buttonActions,undefined);
+	let [leftClickDropDown, leftDoubleClickDropDown] = addDoubleDropDown(settings,group,'left-click-action','left-double-click-action','Left click',buttonActions,buttonActions,undefined);
+	let [middleClickDropDown, middleDoubleClickDropDown] = addDoubleDropDown(settings,group,'middle-click-action','middle-double-click-action','Middle click',buttonActions,buttonActions,undefined);
+	let [rightClickDropDown, rightDoubleClickDropDown] = addDoubleDropDown(settings,group,'right-click-action','right-double-click-action','Right click',buttonActions,buttonActions,undefined);
+	let [thumbForwardDropDown, thumbDoubleForwardDropDown] = addDoubleDropDown(settings,group,'thumb-forward-action','thumb-double-forward-action','Thumb-tip button',buttonActions,buttonActions,undefined);
+	let [thumbBackwardDropDown, thumbDoubleBackwardDropDown] = addDoubleDropDown(settings,group,'thumb-backward-action','thumb-double-backward-action','Inner-thumb button',buttonActions,buttonActions,undefined);
 
 	group = addGroup(page,'');
-	let [scrollDropDown] = addDropDown(group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined,140);
+	let [scrollDropDown] = addDropDown(settings,group,'scroll-action','Scroll up/down',{'volume control':'volume-controls','none':'none'},undefined,140);
 
 	group = addGroup(page,'Behaviour');
-	let [volumeControlDropDown] = addDropDown(group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined,140);
+	let [volumeControlDropDown] = addDropDown(settings,group,'volume-control-scheme','Volume control scheme',{'application':'application','global':'global'},undefined,140);
 
-	addResetButton(group,'Reset Controls settings',[
+	addResetButton(settings,group,'Reset Controls settings',[
 		'enable-double-clicks','double-click-time','left-click-action','left-double-click-action','middle-click-action','middle-double-click-action',
 		'right-click-action','right-double-click-action','scroll-action','thumb-forward-action','thumb-double-forward-action','thumb-backward-action',
 		'thumb-double-backward-action','volume-control-scheme'],[leftClickDropDown, leftDoubleClickDropDown,middleClickDropDown, middleDoubleClickDropDown,
@@ -156,10 +156,10 @@ function addGroup(page,title){
 
 // Adwaita 'Row' functions, they add a row to the target group with the widget(s) specified
 
-function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
+function addSpinButton(settings,group,setting,labelstring,lower,upper,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let thisResetButton = buildResetButton(setting);
+	let thisResetButton = buildResetButton(settings,setting);
 
 	let thisSpinButton = new Gtk.SpinButton({
 		adjustment: new Gtk.Adjustment({
@@ -187,22 +187,22 @@ function addSpinButton(group,setting,labelstring,lower,upper,labeltooltip){
 	return row;
 }
 
-function addDropDownsList(group, settingsList, labelstring, optionsList, labeltooltip,width){
+function addDropDownsList(settings,group, settingsList, labelstring, optionsList, labeltooltip,width){
 	let row = buildActionRow(labelstring,labeltooltip);
 
 	let thisDropDownList = [];//keep list of all dropDowns created (required for reset button generation/visibility)
 	for (let i = 0; i < settingsList.length; i++)//generate dropdown for each setting
-		thisDropDownList.push(buildDropDown(settings, settingsList[i], optionsList[i],width));
+		thisDropDownList.push(buildDropDown(settings,settingsList[i],optionsList[i],width));
 
 	//generate reset button (single button for all drop downs)
-	let thisResetButton = buildDropDownResetButton(settingsList,thisDropDownList,optionsList);
+	let thisResetButton = buildDropDownResetButton(settings,settingsList,thisDropDownList,optionsList);
 	row.add_suffix(thisResetButton);
 
 	for (let i = 0; i < thisDropDownList.length; i++) {
 		thisDropDownList[i].connect('notify::selected-item', () => {
 			settings.set_string(settingsList[i],Object.values(optionsList[i])[thisDropDownList[i].get_selected()]);
 			//set reset button visibility to true if any of the settings is different from default
-			let setVisible = setDropDownResetVisibility(settingsList,thisDropDownList,optionsList);
+			let setVisible = setDropDownResetVisibility(settings,settingsList,thisDropDownList,optionsList);
 			thisResetButton.set_visible(setVisible);
 		});
 		row.add_suffix(thisDropDownList[i]);
@@ -212,22 +212,22 @@ function addDropDownsList(group, settingsList, labelstring, optionsList, labelto
 	return thisDropDownList;
 }
 
-function addDropDown(group,settings,labelstring,options,labeltooltip,width=105){
-	return addDropDownsList(group, [settings], labelstring, [options], labeltooltip,width);
+function addDropDown(settings,group,setting,labelstring,options,labeltooltip,width=105){
+	return addDropDownsList(settings,group, [setting], labelstring, [options], labeltooltip,width);
 }
 
-function addDoubleDropDown(group,setting1,setting2,labelstring,options1,options2,labeltooltip,width=135){
-	return addDropDownsList(group, [setting1,setting2], labelstring, [options1,options2], labeltooltip,width);
+function addDoubleDropDown(settings,group,setting1,setting2,labelstring,options1,options2,labeltooltip,width=135){
+	return addDropDownsList(settings,group, [setting1,setting2], labelstring, [options1,options2], labeltooltip,width);
 }
 
-function addTripleDropDown(group,setting1,setting2,setting3,labelstring,options1,options2,options3,labeltooltip,width=81){
-	return addDropDownsList(group, [setting1,setting2,setting3], labelstring, [options1,options2,options3], labeltooltip,width);
+function addTripleDropDown(settings,group,setting1,setting2,setting3,labelstring,options1,options2,options3,labeltooltip,width=81){
+	return addDropDownsList(settings,group, [setting1,setting2,setting3], labelstring, [options1,options2,options3], labeltooltip,width);
 }
 
-function addSwitch(group,setting,labelstring,labeltooltip){
+function addSwitch(settings,group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let thisResetButton = buildResetButton(setting);
+	let thisResetButton = buildResetButton(settings,setting);
 	row.add_suffix(thisResetButton);
 
 	let thisSwitch = new Gtk.Switch({
@@ -248,10 +248,10 @@ function addSwitch(group,setting,labelstring,labeltooltip){
 	group.add(row)
 }
 
-function addEntry(group,setting,labelstring,labeltooltip){
+function addEntry(settings,group,setting,labelstring,labeltooltip){
 	let row = buildActionRow(labelstring,labeltooltip);
 
-	let thisResetButton = buildResetButton(setting);
+	let thisResetButton = buildResetButton(settings,setting);
 	row.add_suffix(thisResetButton);
 
 	let thisEntry = new Gtk.Entry({
@@ -273,7 +273,7 @@ function addEntry(group,setting,labelstring,labeltooltip){
 	group.add(row)
 }
 
-function addWideEntry(group,setting,placeholder,labeltooltip){
+function addWideEntry(settings,group,setting,placeholder,labeltooltip){
 	let thisEntry = new Gtk.Entry({
 		visible: true,
 		secondary_icon_name: '',
@@ -306,7 +306,7 @@ function addWideEntry(group,setting,placeholder,labeltooltip){
 	return thisEntry;
 }
 
-function addResetButton(group,labelstring,options,dropDowns){
+function addResetButton(settings,group,labelstring,options,dropDowns){
 	let thisButton = buildButton(labelstring, () => {
 		options.forEach(option => {
 			settings.reset(option);
@@ -363,7 +363,7 @@ function buildInfoButton(labeltooltip){
 	return thisInfoButton;
 }
 
-function buildResetButton(setting){
+function buildResetButton(settings,setting){
 	let thisResetButton = new Gtk.Button({
 		valign: Gtk.Align.CENTER,
 		icon_name: 'edit-clear-symbolic-rtl',
@@ -398,7 +398,7 @@ function buildDropDown(settings,setting,options,width){
 	return thisDropDown;
 }
 
-function buildDropDownResetButton(setting,dropDown,options){
+function buildDropDownResetButton(settings,setting,dropDown,options){
 	let thisResetButton = new Gtk.Button({
 		valign: Gtk.Align.CENTER,
 		icon_name: 'edit-clear-symbolic-rtl',
@@ -437,7 +437,7 @@ function buildButton(labelstring,callback){
 
 // helper functions
 
-function setDropDownResetVisibility(settingsList,thisDropDownList,optionsList){ //show reset button if any of the values is different from default
+function setDropDownResetVisibility(settings,settingsList,thisDropDownList,optionsList){ //show reset button if any of the values is different from default
 	let setVisible = false;
 	for (let i = 0; i < thisDropDownList.length; i++) {
 		let thisDropDownValue = Object.values(optionsList[i])[thisDropDownList[i].get_selected()];

--- a/prefs.js
+++ b/prefs.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {Adw,Gio,Gtk} = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;


### PR DESCRIPTION
Hi, I would like to propose some "transparent" updates to the code which don't impact the way it works or looks but will fix some upcoming issues ahead of the transition to gnome 45 based on some the errors I had to fix to get the gnome 45 version.

In the order of the commits, this would be:
- propose to use strict to enforce some "discipline" there
- fix undefined variables (pref.js)
- settings defined as global variable in pref.js
- remove unused dependancies (players.js getIcon() )
- remove unused variables (players.js)
- remove unused function inputs (players.js)
- add schema info to metadata.json
- changes which will become requirements for the gnome45 fork but are transparent for gnome 42 (schema definition, popupMenu Ornament)

The idea would be to merge this and only then introduce the gnome45 PR based on this cleaned up code.