### PR TITLE
More cleanup for future compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -387,7 +387,10 @@ class MprisLabel extends PanelMenu.Button {
 		}
 
 	//settings shortcut:
-		this.menu.addAction(_('Settings'), () => ExtensionUtils.openPrefs());
+		let settingsMenuItem = new PopupMenu.PopupMenuItem('Switch Automatically');
+		settingsMenuItem.setOrnament(PopupMenu.Ornament.NONE); //to force item horizontal alignment
+		settingsMenuItem.connect('activate', () => ExtensionUtils.openPrefs() );
+		this.menu.addMenuItem(settingsMenuItem);
 	}
 
 	_refresh() {

--- a/prefs.js
+++ b/prefs.js
@@ -1,7 +1,6 @@
 const {Adw,Gio,Gtk} = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
-const Config = imports.misc.config;
 
 function init(){}
 


### PR DESCRIPTION
Hello, I noticed a couple more minor changes I'd like to make which apply to the gnome 43/44 version too. It's not 100% necessary to include them in `main` as they can always be part of the gnome45 diff but I though it might be cleaner to merge those first to minimise the differences between the two versions. 

The gnome45 version is now ready to go by the way, I'll publish once this is confirmed.