### PR TITLE
Apply gnome45 patch automatically

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,8 @@ cd "$(dirname "$0")"
 printf "\e[32mCopying extension files to target directory:\n\e[0m"
 cp -Rv ./* $DEFAULT_INSTALL_DIR
 
-gnomeVersion=$(gnome-shell --version | awk -F'[ .]' '{print $3}') #get major Gnome version
-if [ $gnomeVersion -ge 45 ]; then #apply patch if Gnome 45+
+GNOME_VERSION=$(gnome-shell --version | awk -F'[ .]' '{print $3}') #get major Gnome version
+if [ $GNOME_VERSION -ge 45 ]; then #apply patch if Gnome 45+
 	if ! command -v patch > /dev/null #check if patch is installed...
 	then
 		printf "\e\n[31mYou are running GNOME 45 or greater and will need to apply the compatibility patch.\nPlease install the 'patch' utility and rerun this script. See README.md for instructions.\n\n\e[0m"

--- a/install.sh
+++ b/install.sh
@@ -12,14 +12,8 @@ cp -Rv ./* $DEFAULT_INSTALL_DIR
 
 GNOME_VERSION=$(gnome-shell --version | awk -F'[ .]' '{print $3}') #get major Gnome version
 if [ $GNOME_VERSION -ge 45 ]; then #apply patch if Gnome 45+
-	if ! command -v patch > /dev/null #check if patch is installed...
-	then
-		printf "\e\n[31mYou are running GNOME 45 or greater and will need to apply the compatibility patch.\nPlease install the 'patch' utility and rerun this script. See README.md for instructions.\n\n\e[0m"
-		exit 1
-	else
-		printf "\e\n[33mYou are running GNOME 45 or greater. Applying the compatibility patch... \nSee README.md for details.\n\e[0m"
-		patch -d $DEFAULT_INSTALL_DIR < patches/gnome45-compatibility.patch
-	fi
+	echo "You are running GNOME 45 or above. The script will try to patch compatibility for this version. See README.md for details."
+	patch -d $DEFAULT_INSTALL_DIR < patches/gnome45-compatibility.patch && echo "Patch applied!" || echo "Patch failed!" && exit 1
 fi
 
 if [ $XDG_SESSION_TYPE = "x11" ]; then

--- a/install.sh
+++ b/install.sh
@@ -10,12 +10,22 @@ cd "$(dirname "$0")"
 printf "\e[32mCopying extension files to target directory:\n\e[0m"
 cp -Rv ./* $DEFAULT_INSTALL_DIR
 
+gnomeVersion=$(gnome-shell --version | awk -F'[ .]' '{print $3}') #get major Gnome version
+if [ $gnomeVersion -ge 45 ]; then #apply patch if Gnome 45+
+	if ! command -v patch > /dev/null #check if patch is installed...
+	then
+		printf "\e\n[31mYou are running GNOME 45 or greater and will need to apply the compatibility patch.\nPlease install the 'patch' utility and rerun this script. See README.md for instructions.\n\n\e[0m"
+		exit 1
+	else
+		printf "\e\n[33mYou are running GNOME 45 or greater. Applying the compatibility patch... \nSee README.md for details.\n\e[0m"
+		patch -d $DEFAULT_INSTALL_DIR < patches/gnome45-compatibility.patch
+	fi
+fi
+
 if [ $XDG_SESSION_TYPE = "x11" ]; then
 	printf "\n\e[32mAll files copied. \nPlease reload the gnome-shell (shortcut Alt + F2, r) to load the extension.\n\n\e[0m"
 else
 	printf "\n\e[32mAll files copied. \nPlease log out and log back in again to load the extension.\n\n\e[0m"
 fi
-
-printf "\e[33mIf you are running GNOME 45 you will need to apply the compatibility patch. See README.md for instructions.\n\n\e[0m"
 
 cd $OLDPWD


### PR DESCRIPTION
This code checks for the gnome version and applies the patch automatically as long as `patch` is installed (unlikely but wasn't installed on the default gnome-nightly so I though I might as well include the check...). The code applies the changes to the copied files in the target folder rather than the base files so we don't get code changes in the git folder itself.

Let me know if that works on your end.