### PR TITLE
Bug with missing `identity` (Spotube fix)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -455,7 +455,7 @@ class MprisLabel extends PanelMenu.Button {
 			let size = Math.floor(Main.panel.height*ALBUM_SIZE/100);
 
 			const blacklist = ALBUM_BLACKLIST.toLowerCase().replaceAll(' ','').split(',');
-			if(!blacklist.includes(this.player.identity.toLowerCase()))
+			if(!this.player.identity || !blacklist.includes(this.player.identity.toLowerCase()))
 				this.icon = this.player.getArtUrlIcon(size);
 		}
 

--- a/extension.js
+++ b/extension.js
@@ -242,17 +242,17 @@ class MprisLabel extends PanelMenu.Button {
 	_changeVolume(delta){
 		let stream = [];
 		stream[0] = this.volumeControl.get_default_sink();
-		let stream_name = 'System Volume (Global)';
+		let streamName = 'System Volume (Global)';
 
 		const CONTROL_SCHEME = this.settings.get_string('volume-control-scheme');
 
 		if(CONTROL_SCHEME == 'application' && this.player){
-			if(this.stream.length == 0)
+			if(!this.stream || this.stream.length == 0)
 				this._getStream();
 
-			if (this.stream.length > 0){
+			if (this.stream && this.stream.length > 0){ //will fall back to System Volume (Global)
 				stream = this.stream;
-				stream_name = this.player.identity;
+				streamName = this.player.identity;
 			}
 		}
 
@@ -284,7 +284,7 @@ class MprisLabel extends PanelMenu.Button {
 		}
 
 		const icon = Gio.Icon.new_for_string(this._setVolumeIcon(volumeRatio));
-		Main.osdWindowManager.show(monitor, icon, stream_name, volumeRatio);
+		Main.osdWindowManager.show(monitor, icon, streamName, volumeRatio);
 	}
 
 	_getStream(){

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "mprisLabel@moon-0xff.github.com",
     "name": "Media Label and Controls (Mpris Label)",
     "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
-    "version": 25,
+    "version": 26,
     "shell-version": [ "43", "44" ],
     "url": "https://github.com/Moon-0xff/gnome-mpris-label",
     "settings-schema": "org.gnome.shell.extensions.mpris-label"

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "mprisLabel@moon-0xff.github.com",
     "name": "Media Label and Controls (Mpris Label)",
     "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
-    "version": 26,
+    "version": 25,
     "shell-version": [ "43", "44" ],
     "url": "https://github.com/Moon-0xff/gnome-mpris-label",
     "settings-schema": "org.gnome.shell.extensions.mpris-label"

--- a/patches/gnome45-compatibility.patch
+++ b/patches/gnome45-compatibility.patch
@@ -88,7 +88,7 @@ index f1cfc3c..02c002a 100644
 @@ -3,7 +3,7 @@
      "name": "Media Label and Controls (Mpris Label)",
      "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
-     "version": 25,
+     "version": 26,
 -    "shell-version": [ "43", "44" ],
 +    "shell-version": [ "45" ],
      "url": "https://github.com/Moon-0xff/gnome-mpris-label",

--- a/patches/gnome45-compatibility.patch
+++ b/patches/gnome45-compatibility.patch
@@ -88,9 +88,9 @@ index f1cfc3c..02c002a 100644
 @@ -3,7 +3,7 @@
      "name": "Media Label and Controls (Mpris Label)",
      "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
--    "version": 26,
+-    "version": 25,
 -    "shell-version": [ "43", "44" ],
-+    "version": 27,
++    "version": 26,
 +    "shell-version": [ "45" ],
      "url": "https://github.com/Moon-0xff/gnome-mpris-label",
      "settings-schema": "org.gnome.shell.extensions.mpris-label"

--- a/patches/gnome45-compatibility.patch
+++ b/patches/gnome45-compatibility.patch
@@ -88,8 +88,9 @@ index f1cfc3c..02c002a 100644
 @@ -3,7 +3,7 @@
      "name": "Media Label and Controls (Mpris Label)",
      "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
-     "version": 26,
+-    "version": 26,
 -    "shell-version": [ "43", "44" ],
++    "version": 27,
 +    "shell-version": [ "45" ],
      "url": "https://github.com/Moon-0xff/gnome-mpris-label",
      "settings-schema": "org.gnome.shell.extensions.mpris-label"


### PR DESCRIPTION
I recently discovered [Spotube](https://github.com/KRTirtho/spotube) which is an open source which allows to listen to Spotify (even without a premium account). I tried Spotube v3.1.2 and noticed that it didn't have an `identity` field defined. This has now been reported and fixed in V3.2.0: https://github.com/KRTirtho/spotube/issues/811

While this is more of a bug on the side of the app, this allowed me to notice a couple of this which weren't working when this `identity` field is missing although they could still work:
1. the album cover wasn't showing: I have updated the code so the album still appears even when `identity` isn't defined as this should be required.
2. the volume adjustment wasn't working: I have updated the code to fallback on System Sound rather than crashing

I also took the opportunity to update the version number and update `stream_name` to `streamName` for consistency with the rest of the code.