### PR TITLE
Update info button icon to use Adwaita icon 'dialog-information-symbolic'

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -393,7 +393,7 @@ function buildActionRow(labelstring,labeltooltip){
 function buildInfoButton(labeltooltip){
 	let thisInfoButton = new Gtk.MenuButton({
 		valign: Gtk.Align.CENTER,
-		icon_name: 'info-symbolic',
+		icon_name: 'dialog-information-symbolic',
 		visible: true
 	});
 	thisInfoButton.add_css_class('flat');


### PR DESCRIPTION
As #99, our current implementation relies on an icon from Settings (gnome-control-center) which may not be available if the software isn't present or in heavily sandboxed systems. Proposed minor update to info button icon in Preferences window due to currently using a non-Adwaita icon.

Successfully Tested in Gnome 45 and gnome-nightly.
Yaru (Ubuntu default) for which the icon interestingly still looks like an i
![image](https://github.com/Moon-0xff/gnome-mpris-label/assets/56710655/ba2f7b57-36d5-4063-8c9a-ccf5ca6932c5)

Adwaita/gnome-nightly
![image](https://github.com/Moon-0xff/gnome-mpris-label/assets/56710655/19ae99fb-b7f0-4ca7-8352-b546e5757912)

Please check with older versions to make sure this icon already existed.