### PR TITLE
Fix depreciated Clutter.Color for Gnome 47+

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,11 @@ cp -Rv ./* $DEFAULT_INSTALL_DIR
 GNOME_VERSION=$(gnome-shell --version | awk -F'[ .]' '{print $3}') #get major Gnome version
 if [ $GNOME_VERSION -ge 45 ]; then #apply patch if Gnome 45+
 	echo "You are running GNOME 45 or above. The script will try to patch compatibility for this version. See README.md for details."
-	patch -d $DEFAULT_INSTALL_DIR < patches/gnome45-compatibility.patch && echo "Patch applied!" || echo "Patch failed!" && exit 1
+	patch -d $DEFAULT_INSTALL_DIR < patches/gnome45-compatibility.patch && echo "Gnome 45+ Patch applied!" || { echo "Patch failed!"; exit 1 ; }
+	if [ $GNOME_VERSION -ge 47 ]; then #apply patch if Gnome 45+
+		echo "You are running GNOME 47 or above."
+		patch -d $DEFAULT_INSTALL_DIR < patches/gnome47-compatibility.patch && echo "Gnome 47+ Patch applied!" || { echo "Patch failed!"; exit 1 ; }
+	fi
 fi
 
 if [ $XDG_SESSION_TYPE = "x11" ]; then

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ GNOME_VERSION=$(gnome-shell --version | awk -F'[ .]' '{print $3}') #get major Gn
 if [ $GNOME_VERSION -ge 45 ]; then #apply patch if Gnome 45+
 	echo "You are running GNOME 45 or above. The script will try to patch compatibility for this version. See README.md for details."
 	patch -d $DEFAULT_INSTALL_DIR < patches/gnome45-compatibility.patch && echo "Gnome 45+ Patch applied!" || { echo "Patch failed!"; exit 1 ; }
-	if [ $GNOME_VERSION -ge 47 ]; then #apply patch if Gnome 45+
+	if [ $GNOME_VERSION -ge 47 ]; then #apply patch if Gnome 47+
 		echo "You are running GNOME 47 or above."
 		patch -d $DEFAULT_INSTALL_DIR < patches/gnome47-compatibility.patch && echo "Gnome 47+ Patch applied!" || { echo "Patch failed!"; exit 1 ; }
 	fi

--- a/patches/gnome47-compatibility.patch
+++ b/patches/gnome47-compatibility.patch
@@ -1,0 +1,23 @@
+diff --git a/extension.js b/extension.js
+@@ -6,6 +6,7 @@
+ import GLib from 'gi://GLib';
+ import GObject from 'gi://GObject';
+ import St from 'gi://St';
++import Cogl from 'gi://Cogl';
+ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+ import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
+
+@@ -107,7 +108,12 @@
+			new_channels.push(Math.round((channel[0] + channel[1]) / 2));
+		});
+
+-		let mixedColor = Clutter.Color.new(new_channels[0],new_channels[1],new_channels[2],new_channels[3]);
++		let mixedColor = new Cogl.Color({
++			red: new_channels[0],
++			green: new_channels[1],
++			blue: new_channels[2],
++			alpha: new_channels[3]
++		});
+		let color_str = mixedColor.to_string();
+		this.unfocusColor = color_str.substring(0,7); //ignore alpha channel
+	}


### PR DESCRIPTION
Hello,

I noticed in Gnome47 that while everything seemed to work fine, the Menu wasn't showing anymore. Upon inspection, it appears that `determineColors()` was getting blocked by the following updated from Clutter to Cogl: https://gjs.guide/extensions/upgrading/gnome-shell-47.html#clutter-color

See proposed changes applying extra patch on top of the Gnome 45+ patch.