### PR TITLE
plexamp play-pause workaround

### DIFF
--- a/players.js
+++ b/players.js
@@ -3,6 +3,7 @@ const {Gio,Shell,St} = imports.gi;
 const mprisInterface = `
 <node>
 	<interface name="org.mpris.MediaPlayer2.Player">
+		<method name="Play" />
 		<method name="PlayPause" />
 		<method name="Next" />
 		<method name="Previous" />
@@ -263,6 +264,11 @@ class Player {
 	toggleStatus() {
 		if (this.proxy.CanPlay && this.proxy.CanPause){
 			this.proxy.PlayPauseRemote();
+			return
+		}
+		//workaround for some players (Plexamp) which incorrectly change CanPause set to false when paused
+		if (this.proxy.CanPlay && this.proxy.PlaybackStatus == "Paused"){ 
+			this.proxy.PlayRemote();
 			return
 		}
 		if (this.proxy.PlaybackStatus == "Playing"){ // fallback to "Stop"

--- a/players.js
+++ b/players.js
@@ -265,10 +265,12 @@ class Player {
 
 		this.proxy.PlayPauseRemote();
 
-		if (this.proxy.PlaybackStatus == "Playing" && prevStatus == "Playing"){ //fallback to "Stop"
-			this.proxy.StopRemote();
-			return
-		}
+		setTimeout(() => { //wait 1s s PlaybackStatus update has a lag
+			if (this.proxy.PlaybackStatus == "Playing" && prevStatus == "Playing"){ //fallback to "Stop"
+				this.proxy.StopRemote();
+				return
+			}
+		}, 1000);
 	}
 	goNext(){
 		if (this.proxy.CanGoNext)

--- a/players.js
+++ b/players.js
@@ -3,6 +3,7 @@ const {Gio,Shell,St} = imports.gi;
 const mprisInterface = `
 <node>
 	<interface name="org.mpris.MediaPlayer2.Player">
+		<method name="Play" />
 		<method name="PlayPause" />
 		<method name="Next" />
 		<method name="Previous" />
@@ -261,16 +262,19 @@ class Player {
 		return icon
 	}
 	toggleStatus() {
-		let prevStatus = this.proxy.PlaybackStatus;
-
-		this.proxy.PlayPauseRemote();
-
-		setTimeout(() => { //wait 1s s PlaybackStatus update has a lag
-			if (this.proxy.PlaybackStatus == "Playing" && prevStatus == "Playing"){ //fallback to "Stop"
-				this.proxy.StopRemote();
-				return
-			}
-		}, 1000);
+		if (this.proxy.CanPlay && this.proxy.CanPause){
+			this.proxy.PlayPauseRemote();
+			return
+		}
+		//workaround for some players (Plexamp) which incorrectly change CanPause set to false when paused
+		if (this.proxy.CanPlay && this.proxy.PlaybackStatus == "Paused"){ 
+			this.proxy.PlayRemote();
+			return
+		}
+		if (this.proxy.PlaybackStatus == "Playing"){ // fallback to "Stop"
+			this.proxy.StopRemote();
+			return
+		}
 	}
 	goNext(){
 		if (this.proxy.CanGoNext)

--- a/players.js
+++ b/players.js
@@ -3,7 +3,6 @@ const {Gio,Shell,St} = imports.gi;
 const mprisInterface = `
 <node>
 	<interface name="org.mpris.MediaPlayer2.Player">
-		<method name="Play" />
 		<method name="PlayPause" />
 		<method name="Next" />
 		<method name="Previous" />
@@ -262,16 +261,11 @@ class Player {
 		return icon
 	}
 	toggleStatus() {
-		if (this.proxy.CanPlay && this.proxy.CanPause){
-			this.proxy.PlayPauseRemote();
-			return
-		}
-		//workaround for some players (Plexamp) which incorrectly change CanPause set to false when paused
-		if (this.proxy.CanPlay && this.proxy.PlaybackStatus == "Paused"){ 
-			this.proxy.PlayRemote();
-			return
-		}
-		if (this.proxy.PlaybackStatus == "Playing"){ // fallback to "Stop"
+		let prevStatus = this.proxy.PlaybackStatus;
+
+		this.proxy.PlayPauseRemote();
+
+		if (this.proxy.PlaybackStatus == "Playing" && prevStatus == "Playing"){ //fallback to "Stop"
 			this.proxy.StopRemote();
 			return
 		}


### PR DESCRIPTION
I recently started to play with Plex and when installing Plexamp, I noticed that while I could Pause, I couldn't resume the songs. the rest of the funcitonalities works (artwork, song info, ...) so that's good.

on further inspection, he reason PlayPause is flakey is because Plexamp incorrectly sets CanPause to false when the song is paused (see below, CanPause changing from true to false):
![image](https://github.com/user-attachments/assets/2af6aeee-1f27-4fb5-b432-cd9943e2d41a)

If your widget checks for CanPlay && CanPause at the same time to trigger PlayPauseRemote, it will assume that is can’t control the song. Normally, players leave CanPlay and CanPause to true when these functionalities are enabled which is [the way the specification intends it to be](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanPause) so it’s a bug.

I have reported this bug [on the Plexamp forum](https://forums.plex.tv/t/mpris-implementation-flakey/887376/3). However, since it's proprietary, I doubt the Plex team is going to fix it anytime soon so I took it upon myself to include a workaround. Basically, we need to only check CanPlay if the song status is Paused.

Note that technically, we could remove `<method name="Play" />` and use `this.proxy.PlayPauseRemote()`. The main reason I'm using Play is because technically, CanPause is `false` and using Play is a fit clearer in my view. We could change that if you find this overly pedantic.