### PR TITLE
Fix label fitering cutting at the first hyphen instead of the last

### DIFF
--- a/label.js
+++ b/label.js
@@ -67,7 +67,7 @@ function parseMetadataField(data,settings,[LABEL_FILTERED_LIST,MAX_STRING_LENGTH
 			settings.set_string('label-filtered-list',sanitizedInput);
 		}
 
-		const filterRegex = new RegExp("(?:-|\\(|\\[).*(?:" + sanitizedInput.replace(",","|") + ").*(?:$|\\)|\\])","gi");
+		const filterRegex = new RegExp("\\s*(?:-|\\(|\\[)[^-\\(\\[]*(?:" + sanitizedInput.replace(",","|") + ").*(?:$|\\)|\\])","gi");
 
 		data = data.replace(filterRegex,"");
 	}


### PR DESCRIPTION
The label filtering will now only remove the text containing a filtered word from the last "separator" encountered and not the first one.

Also now the spaces before that separator are removed too, so there are no trailing spaces in the end result.

(The separator being a hyphen or an opening bracket.)

So the regex now matches:

- An optional run of spaces (that's new),
- followed by a hyphen or an opening bracket,
- followed by an optional run of anything that is not a hyphen or an opening bracket (that changed),
- followed by one of the filtered word,
- followed by an optional run of any character,
- followed by the end or a closing bracket.

Now that I think about it, that last part is actually useless because the closing bracket would match the case "any characters (which include brackets) followed by the end of the string", so maybe we could just remove it, couldn't we?

Fix #114.