### PR TITLE
Use MPRIS Raise to activate players running in background

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "mprisLabel@moon-0xff.github.com",
     "name": "Media Label and Controls (Mpris Label)",
     "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
-    "version": 37,
+    "version": 42,
     "shell-version": [ "47", "48" ],
     "url": "https://github.com/Moon-0xff/gnome-mpris-label",
     "settings-schema": "org.gnome.shell.extensions.mpris-label"

--- a/patches/gnome49-compatibility.patch
+++ b/patches/gnome49-compatibility.patch
@@ -18,7 +18,7 @@ index b26843a..9888946 100644
 @@ -3,7 +3,7 @@
      "name": "Media Label and Controls (Mpris Label)",
      "description": "Display a label in your panel with the song/title/album/artist information available from an mpris compatible player. You can also control the player, raise/lower its volume, customize the label, and a lot more! This extension works with Spotify, Vlc, Rhythmbox, Firefox, Chromium, and (probably) any MPRIS compatible player.",
-     "version": 37,
+     "version": 42,
 -    "shell-version": [ "47", "48" ],
 +    "shell-version": [ "49" ],
      "url": "https://github.com/Moon-0xff/gnome-mpris-label",

--- a/players.js
+++ b/players.js
@@ -177,6 +177,7 @@ class Player {
 	_onEntryProxyReady(){
 		this.identity = this.entryProxy.Identity;
 		this.desktopEntry = this.entryProxy.DesktopEntry;
+		this.canRaise = this.entryProxy.CanRaise;
 
 		this.desktopApp = null;
 		let matchedEntries = [];
@@ -294,11 +295,11 @@ class Player {
 		let currentWorkspace = global.workspace_manager.get_active_workspace();
 
 		if (!playerWindow){
-			if (this.entryProxy.CanRaise){
+			if (this.canRaise){
 				this.previousWorkspace = currentWorkspace;
 				this.previousWindow = focusedWindow;
 				this.raisedFromBackground = true;
-				this.entryProxy.RaiseRemote();
+				this.entryProxy.RaiseAsync().catch(logError);
 			}
 			return;
 		}


### PR DESCRIPTION
## Summary

- When a player has no window but reports `CanRaise`, use the MPRIS `Raise` method via `entryProxy` to restore the window, instead of silently returning
- Track whether the window was raised from background so that subsequent clicks close the window, sending the player back to its background state (e.g. tray)
- This mirrors the existing minimize/unminimize toggle: if a player was minimized, clicks toggle minimize; if a player was running in the background, clicks toggle the window open/closed
- The flag is reset when the window is found through normal activation, so regular window management is unaffected

The reasoning: if a player has `CanRaise` and no window, it is deliberately running without a window and can restore one on demand. Closing the window is safe because the app is designed for it — otherwise it would have quit and its MPRIS service would be gone.

Closes #131