### PR TITLE
add mpris raise fallback to focus player browser tab

### DIFF
--- a/players.js
+++ b/players.js
@@ -290,6 +290,9 @@ class Player {
 			return
 		}
 	}
+	raise() { //activate source app / browser tab
+		this.entryProxy.RaiseAsync();
+	}
 	goNext(){
 		if (this.proxy.CanGoNext)
 			this.proxy.NextRemote()
@@ -308,7 +311,7 @@ class Player {
 				this.previousWorkspace = currentWorkspace;
 				this.previousWindow = focusedWindow;
 				this.raisedFromBackground = true;
-				this.entryProxy.RaiseAsync().catch(logError);
+				this.raise();
 			}
 			return;
 		}
@@ -335,6 +338,8 @@ class Player {
 				this.previousWindow = focusedWindow;
 				this.playerWindowMinimized = playerWindow.minimized;
 				playerWindow.activate(global.get_current_time());
+				if (this.canRaise) //try to raise player window/tab using mpris if available
+					this.raise();
 			}
 		}
 	}


### PR DESCRIPTION
add mpris raise fallback to window activate to focus player browser tab when available via mpris (eg firefox). Checked on chromium and canRaise doesn't appear to be implemented
```
-> MediaPlayer2 output
 
 string "CanQuit"
 boolean false
 
 string "CanRaise"
 boolean false
 
 string "HasTrackList"
 boolean false
 
 string "Identity"
 string "Chrome"
 ```
should close #117 