### PR TITLE
updating depreciated Gio.DesktopAppInfo  to use GioUnix.DesktopAppInfo

### DIFF
--- a/players.js
+++ b/players.js
@@ -1,4 +1,5 @@
 import Gio from 'gi://Gio';
+import GioUnix from 'gi://GioUnix';
 import Shell from 'gi://Shell';
 import St from 'gi://St';
 
@@ -182,12 +183,12 @@ class Player {
 		this.desktopApp = null;
 		let matchedEntries = [];
 		if(! (this.identity == null | undefined))
-			matchedEntries = Gio.DesktopAppInfo.search(this.identity);
+			matchedEntries = GioUnix.DesktopAppInfo.search(this.identity);
 
 		if ( matchedEntries.length === 0 && !(this.desktopEntry == null | undefined) )//backup method using DesktopEntry info
-			matchedEntries = Gio.DesktopAppInfo.search(this.desktopEntry);
+			matchedEntries = GioUnix.DesktopAppInfo.search(this.desktopEntry);
 
-		//de-nest matchedEntries. Gio.DesktopAppInfo.search returns a nested array
+		//de-nest matchedEntries. GioUnix.DesktopAppInfo.search returns a nested array
 		let entries = [];
 		matchedEntries.forEach(nest => {
 			nest.forEach(entry => {
@@ -270,7 +271,7 @@ class Player {
 		if(this.desktopApp == null | undefined)
 			return icon
 
-		let entry = Gio.DesktopAppInfo.new(this.desktopApp);
+		let entry = GioUnix.DesktopAppInfo.new(this.desktopApp);
 		let gioIcon = entry.get_icon();
 		icon.set_gicon(gioIcon);
 		return icon


### PR DESCRIPTION
updating depreciated `Gio.DesktopAppInfo `to use `GioUnix.DesktopAppInfo`  (updated since Gnome 48) to supress following warning as `Gio.DesktopAppInfo` is apparently expected to be removed with Gnome 50+. This warning appears since Gnome 49 and the new code confirmed to work in Gnome 49.

```js
Gio.DesktopAppInfo has been moved to a separate platform-specific library. Please update your code to use GioUnix.DesktopAppInfo instead.
0 get() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":524:46]
1 _onEntryProxyReady() ["file:///home/anthony/.local/share/gnome-shell/extensions/mprisLabel@moon-0xff.github.com/players.js":185:4]
2 wrapper/<() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":252:36]
3 anonymous() ["resource:///org/gnome/shell/ui/init.js":21:20]

Gio.DesktopAppInfo has been moved to a separate platform-specific library. Please update your code to use GioUnix.DesktopAppInfo instead.
0 get() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":524:46]
1 getIcon() ["file:///home/anthony/.local/share/gnome-shell/extensions/mprisLabel@moon-0xff.github.com/players.js":273:15]
2 _onEntryProxyReady() ["file:///home/anthony/.local/share/gnome-shell/extensions/mprisLabel@moon-0xff.github.com/players.js":202:20]
3 wrapper/<() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":252:36]
4 anonymous() ["resource:///org/gnome/shell/ui/init.js":21:20]
```

same change was made to gsconnect recently: https://github.com/GSConnect/gnome-shell-extension-gsconnect/pull/2119

Note: this is not expected to break compatibility with gnome 47/48 as GioUnix should already be there but I'm unable to test this.