### PR TITLE
Update position crash fix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -63,8 +63,9 @@ class MprisLabel extends PanelMenu.Button {
 
 		this.settings.connect('changed::left-padding',this._onPaddingChanged.bind(this));
 		this.settings.connect('changed::right-padding',this._onPaddingChanged.bind(this));
-		this.settings.connect('changed::extension-index',this._updateTrayPosition.bind(this));
-		this.settings.connect('changed::extension-place',this._updateTrayPosition.bind(this));
+		this._updateTrayPositionPending = false;
+		this.settings.connect('changed::extension-index',() => {this._updateTrayPositionPending = true;});
+		this.settings.connect('changed::extension-place',() => {this._updateTrayPositionPending = true;});
 		this.settings.connect('changed::show-icon',this._setIcon.bind(this));
 		this.settings.connect('changed::use-album',this._setIcon.bind(this));
 		this.settings.connect('changed::symbolic-source-icon', this._setIcon.bind(this));
@@ -72,7 +73,7 @@ class MprisLabel extends PanelMenu.Button {
 
 		Main.panel.addToStatusArea('Mpris Label',this,EXTENSION_INDEX,EXTENSION_PLACE);
 
-		this._repositionTimeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,REPOSITION_DELAY,this._updateTrayPosition.bind(this));
+		this._repositionTimeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT,REPOSITION_DELAY,() => {this._updateTrayPositionPending = true;});
 
 		this.lastClick = new Map(); // place where occurrences of click actions will be stored
 
@@ -122,20 +123,17 @@ class MprisLabel extends PanelMenu.Button {
 		const EXTENSION_PLACE = this.settings.get_string('extension-place');
 		const EXTENSION_INDEX = this.settings.get_int('extension-index');
 
-		if(this._timeout) //prevent refreshes while changing position
-			this._removeTimeout();
-
-		if (this.container.get_parent())
-			this.container.get_parent().remove_child(this.container);
-		else //gnome will issue "Object St.Bin has been already disposed" error but return to prevent crash
+		if (!this.container.get_parent()) //return to prevent crash on delete
 			return
+		
+		this.container.get_parent().remove_child(this.container);
 
 		if (Main.panel.statusArea['Mpris Label'])
 			delete Main.panel.statusArea['Mpris Label'];
 
 		Main.panel.addToStatusArea('Mpris Label',this,EXTENSION_INDEX,EXTENSION_PLACE);
 
-		this._refresh(); //call and re-enable the refresh loop
+		this._updateTrayPositionPending = false; //repositioning completed
 	}
 
 	_onClick(event){
@@ -447,6 +445,9 @@ class MprisLabel extends PanelMenu.Button {
 
 		if(this._timeout) //prevent simultaneous timeouts
 			this._removeTimeout();
+
+		if (this._updateTrayPositionPending) //if signal tiggered a position update
+			this._updateTrayPosition();
 
 		let prevPlayer = this.player;
 

--- a/extension.js
+++ b/extension.js
@@ -130,15 +130,10 @@ class MprisLabel extends PanelMenu.Button {
 		else //gnome will issue "Object St.Bin has been already disposed" error but return to prevent crash
 			return
 
-		if (EXTENSION_PLACE == "left"){
-			Main.panel._leftBox.insert_child_at_index(this.container, EXTENSION_INDEX);
-		}
-		else if (EXTENSION_PLACE == "center"){
-			Main.panel._centerBox.insert_child_at_index(this.container, EXTENSION_INDEX);
-		}
-		else if (EXTENSION_PLACE == "right"){
-			Main.panel._rightBox.insert_child_at_index(this.container, EXTENSION_INDEX);
-		}
+		if (Main.panel.statusArea['Mpris Label'])
+			delete Main.panel.statusArea['Mpris Label'];
+
+		Main.panel.addToStatusArea('Mpris Label',this,EXTENSION_INDEX,EXTENSION_PLACE);
 
 		this._refresh(); //call and re-enable the refresh loop
 	}

--- a/extension.js
+++ b/extension.js
@@ -127,6 +127,8 @@ class MprisLabel extends PanelMenu.Button {
 
 		if (this.container.get_parent())
 			this.container.get_parent().remove_child(this.container);
+		else //gnome will issue "Object St.Bin has been already disposed" error but return to prevent crash
+			return
 
 		if (EXTENSION_PLACE == "left"){
 			Main.panel._leftBox.insert_child_at_index(this.container, EXTENSION_INDEX);
@@ -447,6 +449,10 @@ class MprisLabel extends PanelMenu.Button {
 
 	_refresh() {
 		const REFRESH_RATE = this.settings.get_int('refresh-rate');
+
+		// prevent crash when extension is being recreated while timeout is still running
+		if (!this.container || this.container.is_destroyed?.())
+			return GLib.SOURCE_REMOVE;
 
 		if(this._timeout) //prevent simultaneous timeouts
 			this._removeTimeout();

--- a/extension.js
+++ b/extension.js
@@ -445,10 +445,6 @@ class MprisLabel extends PanelMenu.Button {
 	_refresh() {
 		const REFRESH_RATE = this.settings.get_int('refresh-rate');
 
-		// prevent crash when extension is being recreated while timeout is still running
-		if (!this.container || this.container.is_destroyed?.())
-			return GLib.SOURCE_REMOVE;
-
 		if(this._timeout) //prevent simultaneous timeouts
 			this._removeTimeout();
 

--- a/prefs.js
+++ b/prefs.js
@@ -26,7 +26,7 @@ fillPreferencesWindow(window){
 
 	group = addGroup(page,'Position');
 	let [extensionPlaceDropDown] = addDropDown(settings,group,'extension-place','Extension place',{'left':'left','center':'center','right':'right'},undefined);
-	addSpinButton(settings,group,'extension-index','Extension index',0,20,"Set widget location within with respect to other adjacent widgets");
+	addSpinButton(settings,group,'extension-index','Extension index',0,20,"Set widget location with respect to other adjacent widgets");
 	addSpinButton(settings,group,'left-padding','Left padding',0,500,undefined);
 	addSpinButton(settings,group,'right-padding','Right padding',0,500,undefined);
 


### PR DESCRIPTION
proposed fix for #137 

I included a check with `return` which allows to avoid trying to delete something which isn't accessible... The St.Bin warning is still obscure and will continue to appear in the journal as it's being checked by the `if` statement.

I also took the opportunity to simplify the relocation logic by removing/reinserting the widget rather than trying to relocate it.